### PR TITLE
Error Messages to Client

### DIFF
--- a/samples_project/Assets/SampleViewer/Samples/Routing/RouteManager.cs
+++ b/samples_project/Assets/SampleViewer/Samples/Routing/RouteManager.cs
@@ -84,7 +84,15 @@ public class RouteManager : MonoBehaviour
                     routing = true;
 
                     string results = await FetchRoute(stops.ToArray());
-                    StartCoroutine(DrawRoute(results));
+
+                    if (results.Contains("error"))
+                    {
+                        DisplayError(results);
+                    }
+                    else
+                    {
+                        StartCoroutine(DrawRoute(results));
+                    }
 
                     routing = false;
                 }
@@ -111,6 +119,15 @@ public class RouteManager : MonoBehaviour
         var geoPosition = arcGISMapViewComponent.RendererView.FromCartesianPosition(v3);
 
         return GeoUtils.ProjectToWGS84(geoPosition);
+    }
+
+    private void DisplayError(string error_text)
+    {
+        var error = JObject.Parse(error_text).SelectToken("error");
+        var message = error.SelectToken("message");
+
+        var tmp = RouteInfo.GetComponent<TextMeshProUGUI>();
+        tmp.text = $"Error: {message}";
     }
 
     private async Task<string> FetchRoute(GameObject[] stops)

--- a/samples_project/Assets/SampleViewer/Samples/Routing/Routing.unity
+++ b/samples_project/Assets/SampleViewer/Samples/Routing/Routing.unity
@@ -268,8 +268,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 747}
-  m_SizeDelta: {x: 500, y: 125}
+  m_AnchoredPosition: {x: 172, y: 747}
+  m_SizeDelta: {x: 850, y: 125}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &215868584
 MonoBehaviour:


### PR DESCRIPTION
Added a function to display an error for the 2 following scenarios (see attached images):

- User failed to provide an API Key
- User provided an API Key that is not authorized for routing

![Token](https://user-images.githubusercontent.com/10102092/168681288-4d58d21c-fb66-4eaf-8232-91c7c0afcedc.PNG)

![Unauthorized](https://user-images.githubusercontent.com/10102092/168681297-bfc4a7ca-2ddf-481e-9763-5f2cb0797c19.PNG)

