### PR TITLE
Sam/additions

### DIFF
--- a/samples_project/Assets/SampleViewer/Samples/Routing/Breadcrumb.prefab
+++ b/samples_project/Assets/SampleViewer/Samples/Routing/Breadcrumb.prefab
@@ -27,7 +27,7 @@ Transform:
   m_GameObject: {fileID: 8817086168170497351}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 5, y: 5, z: 5}
+  m_LocalScale: {x: 15, y: 15, z: 15}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}

--- a/samples_project/Assets/SampleViewer/Samples/Routing/Marker.prefab
+++ b/samples_project/Assets/SampleViewer/Samples/Routing/Marker.prefab
@@ -27,7 +27,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3429036118342133567}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 1, z: 0}
+  m_LocalPosition: {x: 0, y: 2, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -124,7 +124,7 @@ Transform:
   m_GameObject: {fileID: 5022259574890728151}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 25, y: 25, z: 25}
+  m_LocalScale: {x: 100, y: 100, z: 100}
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 5632643909688599785}
@@ -156,9 +156,9 @@ MonoBehaviour:
       z: 0
       w: 1
   m_LocalScale:
-    x: 25
-    y: 25
-    z: 25
+    x: 100
+    y: 100
+    z: 100
 --- !u!114 &1015221677309724350
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -208,7 +208,7 @@ Transform:
   m_GameObject: {fileID: 7409945078870497561}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 0.5, y: 1, z: 0.5}
+  m_LocalScale: {x: 0.5, y: 2, z: 0.5}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 6041946974618217634}

--- a/samples_project/Assets/SampleViewer/Samples/Routing/RouteManager.cs
+++ b/samples_project/Assets/SampleViewer/Samples/Routing/RouteManager.cs
@@ -270,7 +270,7 @@ public class RouteManager : MonoBehaviour
         if (breadcrumbs.Count < 1)
             return;
 
-        lineRenderer.widthMultiplier = 5;
+        lineRenderer.widthMultiplier = 30;
 
         var allPoints = new List<Vector3>();
 

--- a/samples_project/Assets/SampleViewer/Scripts/SampleSwitcher.cs
+++ b/samples_project/Assets/SampleViewer/Scripts/SampleSwitcher.cs
@@ -180,6 +180,10 @@ public class SampleSwitcher : MonoBehaviour
     //Exits the Sample Viewer App
     private void doExitGame()
     {
+#if UNITY_EDITOR
+        UnityEditor.EditorApplication.isPlaying = false;
+#else
         Application.Quit();
+#endif
     }
 }


### PR DESCRIPTION
**Sample**

Edits Routing sample and sample viewer

**Summary**

Adds the functionality to the exit button to end play mode in the editor, or quit the application when in standalone.
More importantly makes the route line/pins in the routing sample larger so it can be seen easier by T-Plan and users.

**Tests**

Tested on all platforms standalone, and in MacOS and Windows editor

**ArcGIS Maps SDK Version**

Latest daily build #3577
