### PR TITLE
Fix VR sample logic for Mac

### DIFF
--- a/samples_project/Assets/Editor/BuildSamplesError.cs
+++ b/samples_project/Assets/Editor/BuildSamplesError.cs
@@ -17,6 +17,10 @@ public class BuildSamplesError
         EditorUtility.DisplayDialog("Pipeline Error:", "\nBuilding with both render pipelines installed is not available. Please remove the HDRP package if building for a mobile device, or remove the URP package if building for Windows or MacOS.", "OK");
         
         throw new BuildFailedException("Cannot build with both render pipeline packages installed. Please remove one.");
+#elif USE_OPENXR_PACKAGE && UNITY_STANDALONE_OSX
+        EditorUtility.DisplayDialog("OpenXR Error:", "\nCannot build for MacOS standalone with OpenXR installed. Please remove the OpenXR package with the Package Manager, and uncheck \"VR-Sample" from the Build Settings scene list", "OK");
+        
+        throw new BuildFailedException("Cannot build with OpenXR package installed. Please remove before building for MacOS standalone.");
 #else
         BuildPipeline.BuildPlayer(options);
 #endif

--- a/samples_project/Assets/Editor/BuildSamplesError.cs
+++ b/samples_project/Assets/Editor/BuildSamplesError.cs
@@ -18,9 +18,9 @@ public class BuildSamplesError
         
         throw new BuildFailedException("Cannot build with both render pipeline packages installed. Please remove one.");
 #elif USE_OPENXR_PACKAGE && UNITY_STANDALONE_OSX
-        EditorUtility.DisplayDialog("OpenXR Error:", "\nCannot build for MacOS standalone with OpenXR installed. Please remove the OpenXR package with the Package Manager, and uncheck \"VR-Sample" from the Build Settings scene list", "OK");
+        EditorUtility.DisplayDialog("OpenXR Error:", "\nCannot build for MacOS standalone with OpenXR Plugin installed. Please remove the OpenXR Plugin package with the Package Manager", "OK");
         
-        throw new BuildFailedException("Cannot build with OpenXR package installed. Please remove before building for MacOS standalone.");
+        throw new BuildFailedException("Cannot build with OpenXR Plugin package installed. Please remove before building for MacOS standalone.");
 #else
         BuildPipeline.BuildPlayer(options);
 #endif

--- a/samples_project/Assets/Editor/EditorAssemblyDef.asmdef
+++ b/samples_project/Assets/Editor/EditorAssemblyDef.asmdef
@@ -10,6 +10,11 @@
             "name": "com.unity.render-pipelines.universal",
             "expression": "",
             "define": "USE_URP_PACKAGE"
+        },
+        {
+            "name": "com.unity.xr.openxr",
+            "expression": "",
+            "define": "USE_OPENXR_PACKAGE"
         }
     ]
 }

--- a/samples_project/Assets/SampleViewer/SampleViewer.asmdef
+++ b/samples_project/Assets/SampleViewer/SampleViewer.asmdef
@@ -25,6 +25,11 @@
             "name": "com.unity.render-pipelines.universal",
             "expression": "",
             "define": "USE_URP_PACKAGE"
+        },
+        {
+            "name": "com.unity.xr.openxr",
+            "expression": "",
+            "define": "USE_OPENXR_PACKAGE"
         }
     ],
     "noEngineReferences": false

--- a/samples_project/Assets/SampleViewer/Scripts/AutoImport.cs
+++ b/samples_project/Assets/SampleViewer/Scripts/AutoImport.cs
@@ -23,21 +23,23 @@ public static class CallReImport
             RenderPipelineAsset URPasset = AssetDatabase.LoadAssetAtPath<RenderPipelineAsset>("Assets/SampleViewer/Resources/SampleGraphicSettings/SampleURPipeline.asset");
             GraphicsSettings.renderPipelineAsset = URPasset;
 #endif
-        EditorBuildSettingsScene[] scenes = EditorBuildSettings.scenes;
+            EditorBuildSettingsScene[] scenes = EditorBuildSettings.scenes;
 
-        foreach (EditorBuildSettingsScene scene in scenes)
-        {
-            if (scene.path.Contains("VR"))
+            foreach (EditorBuildSettingsScene scene in scenes)
             {
+                if (scene.path.Contains("VR"))
+                {
 #if USE_OPENXR_PACKAGE
                     scene.enabled = true;
 #else
                     scene.enabled = false;
 #endif
+                }
             }
-        }
+
             reImport();
         }
+
         Events.registeredPackages += Handle;
     }
     static void reImport()

--- a/samples_project/Assets/SampleViewer/Scripts/AutoImport.cs
+++ b/samples_project/Assets/SampleViewer/Scripts/AutoImport.cs
@@ -23,8 +23,20 @@ public static class CallReImport
             RenderPipelineAsset URPasset = AssetDatabase.LoadAssetAtPath<RenderPipelineAsset>("Assets/SampleViewer/Resources/SampleGraphicSettings/SampleURPipeline.asset");
             GraphicsSettings.renderPipelineAsset = URPasset;
 #endif
-        reImport();
+        EditorBuildSettingsScene[] scenes = EditorBuildSettings.scenes;
 
+        foreach (EditorBuildSettingsScene i in scenes)
+        {
+            if (i.path.Contains("VR"))
+            {
+#if USE_OPENXR_PACKAGE
+                    i.enabled = true;
+#else
+                    i.enabled = false;
+#endif
+                }
+            }
+                    reImport();
         }
         Events.registeredPackages += Handle;
     }

--- a/samples_project/Assets/SampleViewer/Scripts/AutoImport.cs
+++ b/samples_project/Assets/SampleViewer/Scripts/AutoImport.cs
@@ -25,14 +25,14 @@ public static class CallReImport
 #endif
         EditorBuildSettingsScene[] scenes = EditorBuildSettings.scenes;
 
-        foreach (EditorBuildSettingsScene i in scenes)
+        foreach (EditorBuildSettingsScene scene in scenes)
         {
-            if (i.path.Contains("VR"))
+            if (scene.path.Contains("VR"))
             {
 #if USE_OPENXR_PACKAGE
-                    i.enabled = true;
+                    scene.enabled = true;
 #else
-                    i.enabled = false;
+                    scene.enabled = false;
 #endif
             }
         }

--- a/samples_project/Assets/SampleViewer/Scripts/AutoImport.cs
+++ b/samples_project/Assets/SampleViewer/Scripts/AutoImport.cs
@@ -34,9 +34,9 @@ public static class CallReImport
 #else
                     i.enabled = false;
 #endif
-                }
             }
-                    reImport();
+        }
+            reImport();
         }
         Events.registeredPackages += Handle;
     }

--- a/samples_project/Assets/SampleViewer/Scripts/SampleSwitcher.cs
+++ b/samples_project/Assets/SampleViewer/Scripts/SampleSwitcher.cs
@@ -118,6 +118,16 @@ public class SampleSwitcher : MonoBehaviour
     private void PopulateSampleSceneList()
     {
         SceneDropdown.options.Clear();
+
+#if !(USE_OPENXR_PACKAGE)
+        if (SceneList.Contains("VR-Sample")){ 
+             SceneList.Remove("VR-Sample");
+        }
+#else
+        if (!SceneList.Contains("VR-Sample")){ 
+             SceneList.Add("VR-Sample");
+        }
+#endif
         SceneDropdown.AddOptions(SceneList);
         AddScene();
     }

--- a/samples_project/Assets/Samples.meta
+++ b/samples_project/Assets/Samples.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 297065544458a44f0b9b7d19b9844471
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
**Sample**

Fixes being able to build the Sample Viewer for MacOS after the introduction of the VR-Sample. 

**Summary**

Adds an error if trying to build for MacOS with the OpenXR package installed, disables the VR-Sample if the OpenXR package is not installed, enables it when it is installed. Does the same for the VR-Sample option in the Scene dropdown.

**Tests**

Tested on MacOS and Windows, building for all platforms

**ArcGIS Maps SDK Version**

Latest Daily build, 3673
