### PR TITLE
Fixes Materials Import

### DIFF
--- a/samples_project/Assets/SampleViewer/Scripts/AutoImport.cs
+++ b/samples_project/Assets/SampleViewer/Scripts/AutoImport.cs
@@ -45,12 +45,7 @@ public static class CallReImport
     static void reImport()
     {
         List<string> importPaths = new List<string>();
-        importPaths.Add("Assets/SampleViewer/Samples/FeatureLayer/StadiumMaterial.mat");
-        importPaths.Add("Assets/SampleViewer/Samples/FeatureLayer/StadiumShader.shadergraph");
-        importPaths.Add("Assets/SampleViewer/Samples/LineOfSight/Materials");
-        importPaths.Add("Assets/SampleViewer/Samples/Routing/Breadcrumb.mat");
-        importPaths.Add("Assets/SampleViewer/Samples/Routing/MarkerBody.mat");
-        importPaths.Add("Assets/SampleViewer/Samples/Routing/MarkerHead.mat");
+        importPaths.Add("Assets/SampleViewer/Samples");
         importPaths.Add("Packages/com.esri.arcgis-maps-sdk/SDK/Resources/Shaders/Materials/URP");
         importPaths.Add("Assets/Samples/ArcGIS Maps SDK for Unity/1.0.0/All Samples/Resources/Materials/URP");
         importPaths.Add("Packages/com.esri.arcgis-maps-sdk/SDK/Resources/Shaders/Materials/HDRP");


### PR DESCRIPTION
**Summary**
Reimports all sample files instead of only specific files. The way I had it before was reimporting only the specified files, which was slightly more efficient but needed to be updated after each new sample was added. The performance decrease is negligible.

**Tests**

Tested on all supported platforms

**ArcGIS Maps SDK Version**

3695
