### PR TITLE
Small fixes

### DIFF
--- a/samples_project/Assets/SampleViewer/Scripts/AutoImport.cs
+++ b/samples_project/Assets/SampleViewer/Scripts/AutoImport.cs
@@ -47,9 +47,8 @@ public static class CallReImport
         List<string> importPaths = new List<string>();
         importPaths.Add("Assets/SampleViewer/Samples");
         importPaths.Add("Packages/com.esri.arcgis-maps-sdk/SDK/Resources/Shaders/Materials/URP");
-        importPaths.Add("Assets/Samples/ArcGIS Maps SDK for Unity/1.0.0/All Samples/Resources/Materials/URP");
         importPaths.Add("Packages/com.esri.arcgis-maps-sdk/SDK/Resources/Shaders/Materials/HDRP");
-        importPaths.Add("Assets/Samples/ArcGIS Maps SDK for Unity/1.0.0/All Samples/Resources/Materials/HDRP");
+        importPaths.Add("Assets/Samples");
 
         foreach (string path in importPaths)
         {

--- a/samples_project/Assets/SampleViewer/Scripts/SampleSwitcher.cs
+++ b/samples_project/Assets/SampleViewer/Scripts/SampleSwitcher.cs
@@ -43,10 +43,6 @@ public class SampleSwitcher : MonoBehaviour
         if (mapComponent != null && mapComponent.APIKey == "")
         {
             mapComponent.APIKey = APIKey;
-#if (UNITY_EDITOR_OSX || UNITY_STANDALONE_OSX || UNITY_IOS)
-            mapComponent.MapType = Esri.GameEngine.Map.ArcGISMapType.Local;
-            mapComponent.EnableExtent = false;
-#endif
         }
     }
 


### PR DESCRIPTION
**Summary**

Removes logic in the SampleSwitcher.cs file that converted global scenes to local scenes when running on MacOS and iOS, because opening Global scenes on those platforms is no longer an issue, and also removes outdated SDK version from the AutoImport script path

**Tests**

Tested to make sure global scenes no longer have issues on Mac and iOS

**ArcGIS Maps SDK Version**

Daily buid 3864