### PR TITLE
improve code, remove conversion method

### DIFF
--- a/samples_project/Assets/SampleViewer/Samples/Measure/Measure.cs
+++ b/samples_project/Assets/SampleViewer/Samples/Measure/Measure.cs
@@ -194,30 +194,14 @@ public class Measure : MonoBehaviour
 
     private void UnitChanged()
     {
-        if (UnitDropdown.options[UnitDropdown.value].text == "Meters")
-        {
-            geodeticDistance = currentUnit.ConvertTo(new ArcGISLinearUnit(ArcGISLinearUnitId.Meters), geodeticDistance);
-            currentUnit = new ArcGISLinearUnit(ArcGISLinearUnitId.Meters);
-            unitTxt = " m";
-        }
-        else if (UnitDropdown.options[UnitDropdown.value].text == "Kilometers")
-        {
-            geodeticDistance = currentUnit.ConvertTo(new ArcGISLinearUnit(ArcGISLinearUnitId.Kilometers), geodeticDistance);
-            currentUnit = new ArcGISLinearUnit(ArcGISLinearUnitId.Kilometers);
-            unitTxt = " km";
-        }
-        else if (UnitDropdown.options[UnitDropdown.value].text == "Miles")
-        {
-            geodeticDistance = currentUnit.ConvertTo(new ArcGISLinearUnit(ArcGISLinearUnitId.Miles), geodeticDistance);
-            currentUnit = new ArcGISLinearUnit(ArcGISLinearUnitId.Miles);
-            unitTxt = " mi";
-        }
-        else if (UnitDropdown.options[UnitDropdown.value].text == "Feet")
-        {
-            geodeticDistance = currentUnit.ConvertTo(new ArcGISLinearUnit(ArcGISLinearUnitId.Feet), geodeticDistance);
-            currentUnit = new ArcGISLinearUnit(ArcGISLinearUnitId.Feet);
-            unitTxt = " ft";
-        }
-        GeodeticDistanceText.text = "Distance: " + Math.Round(geodeticDistance, 3).ToString() + unitTxt;
+        var newLinearUnit = new ArcGISLinearUnit(Enum.Parse<ArcGISLinearUnitId>(UnitDropdown.options[UnitDropdown.value].text));
+        geodeticDistance = currentUnit.ConvertTo(newLinearUnit, geodeticDistance);
+        currentUnit = newLinearUnit;
+        UpdateDisplay();
+    }
+
+    private void UpdateDisplay()
+    {
+        GeodeticDistanceText.text = $"Distance: {Math.Round(geodeticDistance, 3)} {currentUnit.LinearUnitId}";
     }
 }

--- a/samples_project/Assets/SampleViewer/Samples/Measure/Measure.cs
+++ b/samples_project/Assets/SampleViewer/Samples/Measure/Measure.cs
@@ -24,7 +24,6 @@ public class Measure : MonoBehaviour
     public Dropdown UnitDropdown;
     public Button ClearButton;
 
-    private string unitTxt;
     private ArcGISMapComponent arcGISMapComponent;
     private List<GameObject> featurePoints = new List<GameObject>();
     private Stack<GameObject> stops = new Stack<GameObject>();
@@ -41,7 +40,6 @@ public class Measure : MonoBehaviour
 
         lineRenderer = Line.GetComponent<LineRenderer>();
         lastRootPosition = arcGISMapComponent.GetComponent<HPRoot>().RootUniversePosition;
-        unitTxt = " m";
         UnitDropdown.onValueChanged.AddListener(delegate
         {
             UnitChanged();
@@ -74,8 +72,8 @@ public class Measure : MonoBehaviour
                     var lastPoint = lastStop.GetComponent<ArcGISLocationComponent>().Position;
 
                     //calculate distance from last point to this point
-                    geodeticDistance += ArcGISGeometryEngine.DistanceGeodetic(lastPoint, thisPoint, new ArcGISLinearUnit(ArcGISLinearUnitId.Meters), new ArcGISAngularUnit(ArcGISAngularUnitId.Degrees), ArcGISGeodeticCurveType.Geodesic).Distance;
-                    GeodeticDistanceText.text = "Distance: " + Math.Round(geodeticDistance, 3).ToString() + unitTxt;
+                    geodeticDistance += ArcGISGeometryEngine.DistanceGeodetic(lastPoint, thisPoint, currentUnit, new ArcGISAngularUnit(ArcGISAngularUnitId.Degrees), ArcGISGeodeticCurveType.Geodesic).Distance;
+                    UpdateDisplay();
 
                     featurePoints.Add(lastStop);
                     //interpolate middle points between last point and this point
@@ -95,7 +93,7 @@ public class Measure : MonoBehaviour
         var startPoint = start.GetComponent<ArcGISLocationComponent>().Position;
         var endPoint = end.GetComponent<ArcGISLocationComponent>().Position;
 
-        double d = ArcGISGeometryEngine.DistanceGeodetic(startPoint, endPoint, new ArcGISLinearUnit(ArcGISLinearUnitId.Meters), new ArcGISAngularUnit(ArcGISAngularUnitId.Degrees), ArcGISGeodeticCurveType.Geodesic).Distance;
+        double d = ArcGISGeometryEngine.DistanceGeodetic(startPoint, endPoint, currentUnit, new ArcGISAngularUnit(ArcGISAngularUnitId.Degrees), ArcGISGeodeticCurveType.Geodesic).Distance;
         float n = Mathf.Floor((float)d / InterpolationInterval);
         double dx = (end.transform.position.x - start.transform.position.x) / n;
         double dz = (end.transform.position.z - start.transform.position.z) / n;
@@ -167,7 +165,7 @@ public class Measure : MonoBehaviour
         featurePoints.Clear();
         stops.Clear();
         geodeticDistance = 0;
-        GeodeticDistanceText.text = "Distance: " + geodeticDistance + unitTxt;
+        UpdateDisplay();
         if (lineRenderer)
             lineRenderer.positionCount = 0;
     }

--- a/samples_project/Assets/SampleViewer/Samples/Measure/Measure.cs
+++ b/samples_project/Assets/SampleViewer/Samples/Measure/Measure.cs
@@ -4,233 +4,220 @@
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0
 //
 
-using System;
-using System.Collections.Generic;
-using UnityEngine.UI;
 using Esri.ArcGISMapsSDK.Components;
 using Esri.ArcGISMapsSDK.Utils.GeoCoord;
 using Esri.GameEngine.Geometry;
 using Esri.HPFramework;
-using UnityEngine;
+using System;
+using System.Collections.Generic;
 using Unity.Mathematics;
+using UnityEngine;
+using UnityEngine.UI;
 
 public class Measure : MonoBehaviour
 {
-	public GameObject Line;
-	public Text GeodeticDistanceText;
-	private String unitTxt;
-	public GameObject LineMarker;
-	public GameObject InterpolationMarker;
-	public float InterpolationInterval = 100;
-	public Dropdown UnitDropdown;
-	public Button ClearButton;
-	private HPRoot hpRoot;
-	private ArcGISMapComponent arcGISMapComponent;
-	private List<GameObject> featurePoints = new List<GameObject>();
-	private Stack<GameObject> stops = new Stack<GameObject>();
-	private double3 lastRootPosition;
-	private double geodeticDistance = 0;
-	private LineRenderer lineRenderer;
-	private ArcGISLinearUnit currentUnit = new ArcGISLinearUnit(ArcGISLinearUnitId.Meters);
+    public GameObject Line;
+    public Text GeodeticDistanceText;
+    public GameObject LineMarker;
+    public GameObject InterpolationMarker;
+    public float InterpolationInterval = 100;
+    public Dropdown UnitDropdown;
+    public Button ClearButton;
 
-	void Start()
-	{
-		// We need HPRoot for the HitToGeoPosition Method
-		hpRoot = FindObjectOfType<HPRoot>();
+    private string unitTxt;
+    private ArcGISMapComponent arcGISMapComponent;
+    private List<GameObject> featurePoints = new List<GameObject>();
+    private Stack<GameObject> stops = new Stack<GameObject>();
+    private double3 lastRootPosition;
+    private double geodeticDistance = 0;
+    private LineRenderer lineRenderer;
+    private ArcGISLinearUnit currentUnit = new ArcGISLinearUnit(ArcGISLinearUnitId.Meters);
 
-		// We need this ArcGISMapComponent for the FromCartesianPosition Method
-		// defined on the ArcGISMapComponent.View
-		arcGISMapComponent = FindObjectOfType<ArcGISMapComponent>();
+    private void Start()
+    {
+        // We need this ArcGISMapComponent for the FromCartesianPosition Method
+        // defined on the ArcGISMapComponent.View
+        arcGISMapComponent = FindObjectOfType<ArcGISMapComponent>();
 
-		lineRenderer = Line.GetComponent<LineRenderer>();
-		lastRootPosition = arcGISMapComponent.GetComponent<HPRoot>().RootUniversePosition;
-		unitTxt = " m";
-		UnitDropdown.onValueChanged.AddListener(delegate
-		{
-			UnitChanged();
-		});
-		ClearButton.onClick.AddListener(delegate
-		{
-			ClearLine();
-		});
+        lineRenderer = Line.GetComponent<LineRenderer>();
+        lastRootPosition = arcGISMapComponent.GetComponent<HPRoot>().RootUniversePosition;
+        unitTxt = " m";
+        UnitDropdown.onValueChanged.AddListener(delegate
+        {
+            UnitChanged();
+        });
+        ClearButton.onClick.AddListener(delegate
+        {
+            ClearLine();
+        });
+    }
 
+    private void Update()
+    {
+        if (Input.GetKey(KeyCode.LeftShift) && Input.GetMouseButtonDown(0))
+        {
+            RaycastHit hit;
+            Ray ray = Camera.main.ScreenPointToRay(Input.mousePosition);
 
-	}
+            if (Physics.Raycast(ray, out hit))
+            {
+                var lineMarker = Instantiate(LineMarker, hit.point, Quaternion.identity, arcGISMapComponent.transform);
+                var thisPoint = arcGISMapComponent.EngineToGeographic(hit.point);
 
-	void Update()
-	{
+                lineMarker.GetComponent<ArcGISLocationComponent>().enabled = true;
+                lineMarker.GetComponent<ArcGISLocationComponent>().Position = thisPoint;
+                lineMarker.GetComponent<ArcGISLocationComponent>().Rotation = new ArcGISRotation(0, 90, 0);
 
-		if (Input.GetKey(KeyCode.LeftShift) && Input.GetMouseButtonDown(0))
-		{
-			RaycastHit hit;
-			Ray ray = Camera.main.ScreenPointToRay(Input.mousePosition);
+                if (stops.Count > 0)
+                {
+                    GameObject lastStop = stops.Peek();
+                    var lastPoint = lastStop.GetComponent<ArcGISLocationComponent>().Position;
 
-			if (Physics.Raycast(ray, out hit))
-			{
-				var lineMarker = Instantiate(LineMarker, hit.point, Quaternion.identity, arcGISMapComponent.transform);
-				var thisPoint = arcGISMapComponent.EngineToGeographic(hit.point);
+                    //calculate distance from last point to this point
+                    geodeticDistance += ArcGISGeometryEngine.DistanceGeodetic(lastPoint, thisPoint, new ArcGISLinearUnit(ArcGISLinearUnitId.Meters), new ArcGISAngularUnit(ArcGISAngularUnitId.Degrees), ArcGISGeodeticCurveType.Geodesic).Distance;
+                    GeodeticDistanceText.text = "Distance: " + Math.Round(geodeticDistance, 3).ToString() + unitTxt;
 
-				lineMarker.GetComponent<ArcGISLocationComponent>().enabled = true;
-				lineMarker.GetComponent<ArcGISLocationComponent>().Position = thisPoint;
-				lineMarker.GetComponent<ArcGISLocationComponent>().Rotation = new ArcGISRotation(0, 90, 0);
+                    featurePoints.Add(lastStop);
+                    //interpolate middle points between last point and this point
+                    Interpolate(lastStop, lineMarker, featurePoints);
+                    featurePoints.Add(lineMarker);
+                }
+                //add this point to stops and also to feature points where stop is user-drawed, and feature points is a collection of user-drawed and interpolated
+                stops.Push(lineMarker);
+                RenderLine(ref featurePoints);
+                RebaseLine();
+            }
+        }
+    }
 
-				if (stops.Count > 0)
-				{
-					GameObject lastStop = stops.Peek();
-					var lastPoint = lastStop.GetComponent<ArcGISLocationComponent>().Position;
+    private void Interpolate(GameObject start, GameObject end, List<GameObject> featurePoints)
+    {
+        var startPoint = start.GetComponent<ArcGISLocationComponent>().Position;
+        var endPoint = end.GetComponent<ArcGISLocationComponent>().Position;
 
-					//calculate distance from last point to this point
-					geodeticDistance += ArcGISGeometryEngine.DistanceGeodetic(lastPoint, thisPoint, new ArcGISLinearUnit(ArcGISLinearUnitId.Meters), new ArcGISAngularUnit(ArcGISAngularUnitId.Degrees), ArcGISGeodeticCurveType.Geodesic).Distance;
-					GeodeticDistanceText.text = "Distance: " + Math.Round(geodeticDistance, 3).ToString() + unitTxt;
+        double d = ArcGISGeometryEngine.DistanceGeodetic(startPoint, endPoint, new ArcGISLinearUnit(ArcGISLinearUnitId.Meters), new ArcGISAngularUnit(ArcGISAngularUnitId.Degrees), ArcGISGeodeticCurveType.Geodesic).Distance;
+        float n = Mathf.Floor((float)d / InterpolationInterval);
+        double dx = (end.transform.position.x - start.transform.position.x) / n;
+        double dz = (end.transform.position.z - start.transform.position.z) / n;
 
-					featurePoints.Add(lastStop);
-					//interpolate middle points between last point and this point
-					Interpolate(lastStop, lineMarker, featurePoints);
-					featurePoints.Add(lineMarker);
+        var pre = start.transform.position;
 
-				}
-				//add this point to stops and also to feature points where stop is user-drawed, and feature points is a collection of user-drawed and interpolated
-				stops.Push(lineMarker);
-				RenderLine(ref featurePoints);
-				RebaseLine();
+        //calculate n-1 intepolation points/n-1 segments because the last segment is already created by the end point
+        for (int i = 0; i < n - 1; i++)
+        {
+            GameObject next = Instantiate(InterpolationMarker, arcGISMapComponent.transform);
 
-			}
+            //calculate transform of next point
+            float nextX = pre.x + (float)dx;
+            float nextZ = pre.z + (float)dz;
+            next.transform.position = new Vector3(nextX, 0, nextZ);
 
-		}
-	}
+            //set default location component of next point
+            next.GetComponent<ArcGISLocationComponent>().enabled = true;
+            next.GetComponent<ArcGISLocationComponent>().Rotation = new ArcGISRotation(0, 90, 0);
 
-	private void Interpolate(GameObject start, GameObject end, List<GameObject> featurePoints)
-	{
-		var startPoint = start.GetComponent<ArcGISLocationComponent>().Position;
-		var endPoint = end.GetComponent<ArcGISLocationComponent>().Position;
+            //define height
+            SetElevation(next);
 
-		double d = ArcGISGeometryEngine.DistanceGeodetic(startPoint, endPoint, new ArcGISLinearUnit(ArcGISLinearUnitId.Meters), new ArcGISAngularUnit(ArcGISAngularUnitId.Degrees), ArcGISGeodeticCurveType.Geodesic).Distance;
-		float n = Mathf.Floor((float)d / InterpolationInterval);
-		double dx = (end.transform.position.x - start.transform.position.x) / n;
-		double dz = (end.transform.position.z - start.transform.position.z) / n;
+            featurePoints.Add(next);
 
-		var pre = start.transform.position;
+            pre = next.transform.position;
+        }
+    }
 
-		//calculate n-1 intepolation points/n-1 segments because the last segment is already created by the end point 
-		for (int i = 0; i < n - 1; i++)
-		{
-			GameObject next = Instantiate(InterpolationMarker, arcGISMapComponent.transform);
+    // set height for point transform and location component
+    private void SetElevation(GameObject stop)
+    {
+        // start the raycast in the air at an arbitrary to ensure it is above the ground
+        var raycastHeight = 5000;
+        var position = stop.transform.position;
+        var raycastStart = new Vector3(position.x, position.y + raycastHeight, position.z);
+        if (Physics.Raycast(raycastStart, Vector3.down, out RaycastHit hitInfo))
+        {
+            var location = stop.GetComponent<ArcGISLocationComponent>();
+            location.Position = arcGISMapComponent.EngineToGeographic(hitInfo.point);
+            stop.transform.position = hitInfo.point;
+        }
+    }
 
-			//calculate transform of next point
-			float nextX = pre.x + (float)dx;
-			float nextZ = pre.z + (float)dz;
-			next.transform.position = new Vector3(nextX, 0, nextZ);
+    private void RenderLine(ref List<GameObject> featurePoints)
+    {
+        lineRenderer.widthMultiplier = 5;
 
-			//set default location component of next point
-			next.GetComponent<ArcGISLocationComponent>().enabled = true;
-			next.GetComponent<ArcGISLocationComponent>().Rotation = new ArcGISRotation(0, 90, 0);
+        var allPoints = new List<Vector3>();
 
-			//define height
-			SetElevation(next);
+        foreach (var stop in featurePoints)
+        {
+            if (stop.transform.position.Equals(Vector3.zero))
+            {
+                Destroy(stop);
+                continue;
+            }
+            allPoints.Add(stop.transform.position);
+        }
 
-			featurePoints.Add(next);
+        lineRenderer.positionCount = allPoints.Count;
+        lineRenderer.SetPositions(allPoints.ToArray());
+    }
 
-			pre = next.transform.position;
-		}
+    public void ClearLine()
+    {
+        foreach (var stop in featurePoints)
+            Destroy(stop);
+        featurePoints.Clear();
+        stops.Clear();
+        geodeticDistance = 0;
+        GeodeticDistanceText.text = "Distance: " + geodeticDistance + unitTxt;
+        if (lineRenderer)
+            lineRenderer.positionCount = 0;
+    }
 
-	}
+    private void RebaseLine()
+    {
+        var rootPosition = arcGISMapComponent.GetComponent<HPRoot>().RootUniversePosition;
+        var delta = (lastRootPosition - rootPosition).ToVector3();
+        if (delta.magnitude > 1) // 1km
+        {
+            if (lineRenderer != null)
+            {
+                Vector3[] points = new Vector3[lineRenderer.positionCount];
+                lineRenderer.GetPositions(points);
+                for (int i = 0; i < points.Length; i++)
+                {
+                    points[i] += delta;
+                }
+                lineRenderer.SetPositions(points);
+            }
+            lastRootPosition = rootPosition;
+        }
+    }
 
-	// set height for point transform and location component
-	void SetElevation(GameObject stop)
-	{
-		// start the raycast in the air at an arbitrary to ensure it is above the ground
-		var raycastHeight = 5000;
-		var position = stop.transform.position;
-		var raycastStart = new Vector3(position.x, position.y + raycastHeight, position.z);
-		if (Physics.Raycast(raycastStart, Vector3.down, out RaycastHit hitInfo))
-		{
-			var location = stop.GetComponent<ArcGISLocationComponent>();
-			location.Position = arcGISMapComponent.EngineToGeographic(hitInfo.point);
-			stop.transform.position = hitInfo.point;
-		}
-	}
-
-	private void RenderLine(ref List<GameObject> featurePoints)
-	{
-
-		lineRenderer.widthMultiplier = 5;
-
-		var allPoints = new List<Vector3>();
-
-		foreach (var stop in featurePoints)
-		{
-			if (stop.transform.position.Equals(Vector3.zero))
-			{
-				Destroy(stop);
-				continue;
-			}
-			allPoints.Add(stop.transform.position);
-		}
-
-		lineRenderer.positionCount = allPoints.Count;
-		lineRenderer.SetPositions(allPoints.ToArray());
-	}
-
-	public void ClearLine()
-	{
-		foreach (var stop in featurePoints)
-			Destroy(stop);
-		featurePoints.Clear();
-		stops.Clear();
-		geodeticDistance = 0;
-		GeodeticDistanceText.text = "Distance: " + geodeticDistance + unitTxt;
-		if (lineRenderer)
-			lineRenderer.positionCount = 0;
-
-	}
-
-	private void RebaseLine()
-	{
-		var rootPosition = arcGISMapComponent.GetComponent<HPRoot>().RootUniversePosition;
-		var delta = (lastRootPosition - rootPosition).ToVector3();
-		if (delta.magnitude > 1) // 1km
-		{
-			if (lineRenderer != null)
-			{
-				Vector3[] points = new Vector3[lineRenderer.positionCount];
-				lineRenderer.GetPositions(points);
-				for (int i = 0; i < points.Length; i++)
-				{
-					points[i] += delta;
-				}
-				lineRenderer.SetPositions(points);
-			}
-			lastRootPosition = rootPosition;
-		}
-	}
-
-	void UnitChanged()
-	{
-		if (UnitDropdown.options[UnitDropdown.value].text == "Meters")
-		{
-			geodeticDistance = currentUnit.ConvertTo(new ArcGISLinearUnit(ArcGISLinearUnitId.Meters), geodeticDistance);
-			currentUnit = new ArcGISLinearUnit(ArcGISLinearUnitId.Meters);
-			unitTxt = " m";
-		}
-		else if (UnitDropdown.options[UnitDropdown.value].text == "Kilometers")
-		{
-			geodeticDistance = currentUnit.ConvertTo(new ArcGISLinearUnit(ArcGISLinearUnitId.Kilometers), geodeticDistance);
-			currentUnit = new ArcGISLinearUnit(ArcGISLinearUnitId.Kilometers);
-			unitTxt = " km";
-		}
-		else if (UnitDropdown.options[UnitDropdown.value].text == "Miles")
-		{
-			geodeticDistance = currentUnit.ConvertTo(new ArcGISLinearUnit(ArcGISLinearUnitId.Miles), geodeticDistance);
-			currentUnit = new ArcGISLinearUnit(ArcGISLinearUnitId.Miles);
-			unitTxt = " mi";
-		}
-		else if (UnitDropdown.options[UnitDropdown.value].text == "Feet")
-		{
-			geodeticDistance = currentUnit.ConvertTo(new ArcGISLinearUnit(ArcGISLinearUnitId.Feet), geodeticDistance);
-			currentUnit = new ArcGISLinearUnit(ArcGISLinearUnitId.Feet);
-			unitTxt = " ft";
-		}
-		GeodeticDistanceText.text = "Distance: " + Math.Round(geodeticDistance, 3).ToString() + unitTxt;
-	}
-
+    private void UnitChanged()
+    {
+        if (UnitDropdown.options[UnitDropdown.value].text == "Meters")
+        {
+            geodeticDistance = currentUnit.ConvertTo(new ArcGISLinearUnit(ArcGISLinearUnitId.Meters), geodeticDistance);
+            currentUnit = new ArcGISLinearUnit(ArcGISLinearUnitId.Meters);
+            unitTxt = " m";
+        }
+        else if (UnitDropdown.options[UnitDropdown.value].text == "Kilometers")
+        {
+            geodeticDistance = currentUnit.ConvertTo(new ArcGISLinearUnit(ArcGISLinearUnitId.Kilometers), geodeticDistance);
+            currentUnit = new ArcGISLinearUnit(ArcGISLinearUnitId.Kilometers);
+            unitTxt = " km";
+        }
+        else if (UnitDropdown.options[UnitDropdown.value].text == "Miles")
+        {
+            geodeticDistance = currentUnit.ConvertTo(new ArcGISLinearUnit(ArcGISLinearUnitId.Miles), geodeticDistance);
+            currentUnit = new ArcGISLinearUnit(ArcGISLinearUnitId.Miles);
+            unitTxt = " mi";
+        }
+        else if (UnitDropdown.options[UnitDropdown.value].text == "Feet")
+        {
+            geodeticDistance = currentUnit.ConvertTo(new ArcGISLinearUnit(ArcGISLinearUnitId.Feet), geodeticDistance);
+            currentUnit = new ArcGISLinearUnit(ArcGISLinearUnitId.Feet);
+            unitTxt = " ft";
+        }
+        GeodeticDistanceText.text = "Distance: " + Math.Round(geodeticDistance, 3).ToString() + unitTxt;
+    }
 }

--- a/samples_project/Assets/SampleViewer/Samples/Measure/Measure.cs
+++ b/samples_project/Assets/SampleViewer/Samples/Measure/Measure.cs
@@ -14,272 +14,223 @@ using Esri.HPFramework;
 using UnityEngine;
 using Unity.Mathematics;
 
-public enum UnitType
-{
-    m = 0,
-    km = 1,
-    mi = 2,
-    ft = 3
-}
-
 public class Measure : MonoBehaviour
 {
-    public GameObject Line;
-    public Text GeodedicDistanceText;
-    private String unitTxt;
-    public GameObject LineMarker;
-    public GameObject InterpolationMarker;
-    public float InterpolationInterval = 100;
-    public Dropdown UnitDropdown;
-    public Button ClearButton;
-    private HPRoot hpRoot;
-    private ArcGISMapComponent arcGISMapComponent;
-    private float elevationOffset = 5f;
-    private List<GameObject> featurePoints = new List<GameObject>();
-    private Stack<GameObject> stops = new Stack<GameObject>();
-    private double3 lastRootPosition;
-    private double geodedicDistance = 0;
-    private LineRenderer lineRenderer;
-    private ArcGISLinearUnitId unit;
-    private ArcGISAngularUnitId unitDegree = (ArcGISAngularUnitId)9102;
-    private UnitType currentUnit;
+	public GameObject Line;
+	public Text GeodeticDistanceText;
+	private String unitTxt;
+	public GameObject LineMarker;
+	public GameObject InterpolationMarker;
+	public float InterpolationInterval = 100;
+	public Dropdown UnitDropdown;
+	public Button ClearButton;
+	private HPRoot hpRoot;
+	private ArcGISMapComponent arcGISMapComponent;
+	private List<GameObject> featurePoints = new List<GameObject>();
+	private Stack<GameObject> stops = new Stack<GameObject>();
+	private double3 lastRootPosition;
+	private double geodeticDistance = 0;
+	private LineRenderer lineRenderer;
+	private ArcGISLinearUnit currentUnit = new ArcGISLinearUnit(ArcGISLinearUnitId.Meters);
 
-    void Start()
-    {
-        // We need HPRoot for the HitToGeoPosition Method
-        hpRoot = FindObjectOfType<HPRoot>();
+	void Start()
+	{
+		// We need HPRoot for the HitToGeoPosition Method
+		hpRoot = FindObjectOfType<HPRoot>();
 
-        // We need this ArcGISMapComponent for the FromCartesianPosition Method
-        // defined on the ArcGISMapComponent.View
-        arcGISMapComponent = FindObjectOfType<ArcGISMapComponent>();
+		// We need this ArcGISMapComponent for the FromCartesianPosition Method
+		// defined on the ArcGISMapComponent.View
+		arcGISMapComponent = FindObjectOfType<ArcGISMapComponent>();
 
-        lineRenderer = Line.GetComponent<LineRenderer>();
-        lastRootPosition = arcGISMapComponent.GetComponent<HPRoot>().RootUniversePosition;
-        unit = (ArcGISLinearUnitId)9001;
-        currentUnit = UnitType.m;
-        unitTxt = " m";
-        UnitDropdown.onValueChanged.AddListener(delegate
-        {
-            UnitChanged();
-        });
-        ClearButton.onClick.AddListener(delegate
-        {
-            ClearLine();
-        });
+		lineRenderer = Line.GetComponent<LineRenderer>();
+		lastRootPosition = arcGISMapComponent.GetComponent<HPRoot>().RootUniversePosition;
+		unitTxt = " m";
+		UnitDropdown.onValueChanged.AddListener(delegate
+		{
+			UnitChanged();
+		});
+		ClearButton.onClick.AddListener(delegate
+		{
+			ClearLine();
+		});
 
 
-    }
+	}
 
-    void Update()
-    {
+	void Update()
+	{
 
-        if (Input.GetKey(KeyCode.LeftShift) && Input.GetMouseButtonDown(0))
-        {
-            RaycastHit hit;
-            Ray ray = Camera.main.ScreenPointToRay(Input.mousePosition);
+		if (Input.GetKey(KeyCode.LeftShift) && Input.GetMouseButtonDown(0))
+		{
+			RaycastHit hit;
+			Ray ray = Camera.main.ScreenPointToRay(Input.mousePosition);
 
-            if (Physics.Raycast(ray, out hit))
-            {
-                var lineMarker = Instantiate(LineMarker, hit.point, Quaternion.identity, arcGISMapComponent.transform);
+			if (Physics.Raycast(ray, out hit))
+			{
+				var lineMarker = Instantiate(LineMarker, hit.point, Quaternion.identity, arcGISMapComponent.transform);
+				var thisPoint = arcGISMapComponent.EngineToGeographic(hit.point);
 
-                var thisPoint = HitToGeoPosition(hit);
+				lineMarker.GetComponent<ArcGISLocationComponent>().enabled = true;
+				lineMarker.GetComponent<ArcGISLocationComponent>().Position = thisPoint;
+				lineMarker.GetComponent<ArcGISLocationComponent>().Rotation = new ArcGISRotation(0, 90, 0);
 
-                lineMarker.GetComponent<ArcGISLocationComponent>().enabled = true;
-                lineMarker.GetComponent<ArcGISLocationComponent>().Position = thisPoint;
-                lineMarker.GetComponent<ArcGISLocationComponent>().Rotation = new ArcGISRotation(0, 90, 0);
+				if (stops.Count > 0)
+				{
+					GameObject lastStop = stops.Peek();
+					var lastPoint = lastStop.GetComponent<ArcGISLocationComponent>().Position;
 
+					//calculate distance from last point to this point
+					geodeticDistance += ArcGISGeometryEngine.DistanceGeodetic(lastPoint, thisPoint, new ArcGISLinearUnit(ArcGISLinearUnitId.Meters), new ArcGISAngularUnit(ArcGISAngularUnitId.Degrees), ArcGISGeodeticCurveType.Geodesic).Distance;
+					GeodeticDistanceText.text = "Distance: " + Math.Round(geodeticDistance, 3).ToString() + unitTxt;
 
-                if (stops.Count > 0)
-                {
-                    GameObject lastStop = stops.Peek();
-                    var lastPoint = lastStop.GetComponent<ArcGISLocationComponent>().Position;
+					featurePoints.Add(lastStop);
+					//interpolate middle points between last point and this point
+					Interpolate(lastStop, lineMarker, featurePoints);
+					featurePoints.Add(lineMarker);
 
-                    //calculate distance from last point to this point
-                    geodedicDistance += ArcGISGeometryEngine.DistanceGeodetic(lastPoint, thisPoint, new ArcGISLinearUnit(unit), new ArcGISAngularUnit(unitDegree), ArcGISGeodeticCurveType.Geodesic).Distance;
-                    GeodedicDistanceText.text = "Distance: " + Math.Round(geodedicDistance, 3).ToString() + unitTxt;
+				}
+				//add this point to stops and also to feature points where stop is user-drawed, and feature points is a collection of user-drawed and interpolated
+				stops.Push(lineMarker);
+				RenderLine(ref featurePoints);
+				RebaseLine();
 
-                    featurePoints.Add(lastStop);
-                    //interpolate middle points between last point and this point
-                    Interpolate(lastStop, lineMarker, featurePoints);
-                    featurePoints.Add(lineMarker);
+			}
 
-                }
-                //add this point to stops and also to feature points where stop is user-drawed, and feature points is a collection of user-drawed and interpolated
-                stops.Push(lineMarker);
-                RenderLine(ref featurePoints);
-                RebaseLine();
+		}
+	}
 
-            }
+	private void Interpolate(GameObject start, GameObject end, List<GameObject> featurePoints)
+	{
+		var startPoint = start.GetComponent<ArcGISLocationComponent>().Position;
+		var endPoint = end.GetComponent<ArcGISLocationComponent>().Position;
 
-        }
+		double d = ArcGISGeometryEngine.DistanceGeodetic(startPoint, endPoint, new ArcGISLinearUnit(ArcGISLinearUnitId.Meters), new ArcGISAngularUnit(ArcGISAngularUnitId.Degrees), ArcGISGeodeticCurveType.Geodesic).Distance;
+		float n = Mathf.Floor((float)d / InterpolationInterval);
+		double dx = (end.transform.position.x - start.transform.position.x) / n;
+		double dz = (end.transform.position.z - start.transform.position.z) / n;
 
+		var pre = start.transform.position;
 
-    }
+		//calculate n-1 intepolation points/n-1 segments because the last segment is already created by the end point 
+		for (int i = 0; i < n - 1; i++)
+		{
+			GameObject next = Instantiate(InterpolationMarker, arcGISMapComponent.transform);
 
-    private void Interpolate(GameObject start, GameObject end, List<GameObject> featurePoints)
-    {
-        var startPoint = start.GetComponent<ArcGISLocationComponent>().Position;
-        var endPoint = end.GetComponent<ArcGISLocationComponent>().Position;
+			//calculate transform of next point
+			float nextX = pre.x + (float)dx;
+			float nextZ = pre.z + (float)dz;
+			next.transform.position = new Vector3(nextX, 0, nextZ);
 
-        double d = ArcGISGeometryEngine.DistanceGeodetic(startPoint, endPoint, new ArcGISLinearUnit((ArcGISLinearUnitId)9001), new ArcGISAngularUnit(unitDegree), ArcGISGeodeticCurveType.Geodesic).Distance;
-        float n = Mathf.Floor((float)d / InterpolationInterval);
-        double dx = (end.transform.position.x - start.transform.position.x) / n;
-        double dz = (end.transform.position.z - start.transform.position.z) / n;
+			//set default location component of next point
+			next.GetComponent<ArcGISLocationComponent>().enabled = true;
+			next.GetComponent<ArcGISLocationComponent>().Rotation = new ArcGISRotation(0, 90, 0);
 
-        var pre = start.transform.position;
+			//define height
+			SetElevation(next);
 
-        //calculate n-1 intepolation points/n-1 segments because the last segment is already created by the end point 
-        for (int i = 0; i < n - 1; i++)
-        {
-            GameObject next = Instantiate(InterpolationMarker, arcGISMapComponent.transform);
+			featurePoints.Add(next);
 
-            //calculate transform of next point
-            float nextX = pre.x + (float)dx;
-            float nextZ = pre.z + (float)dz;
-            next.transform.position = new Vector3(nextX, 0, nextZ);
+			pre = next.transform.position;
+		}
 
-            //set default location component of next point
-            next.GetComponent<ArcGISLocationComponent>().enabled = true;
-            next.GetComponent<ArcGISLocationComponent>().Rotation = new ArcGISRotation(0, 90, 0);
+	}
 
-            //define height
-            SetElevation(next);
+	// set height for point transform and location component
+	void SetElevation(GameObject stop)
+	{
+		// start the raycast in the air at an arbitrary to ensure it is above the ground
+		var raycastHeight = 5000;
+		var position = stop.transform.position;
+		var raycastStart = new Vector3(position.x, position.y + raycastHeight, position.z);
+		if (Physics.Raycast(raycastStart, Vector3.down, out RaycastHit hitInfo))
+		{
+			var location = stop.GetComponent<ArcGISLocationComponent>();
+			location.Position = arcGISMapComponent.EngineToGeographic(hitInfo.point);
+			stop.transform.position = hitInfo.point;
+		}
+	}
 
-            featurePoints.Add(next);
+	private void RenderLine(ref List<GameObject> featurePoints)
+	{
 
-            pre = next.transform.position;
-        }
+		lineRenderer.widthMultiplier = 5;
 
-    }
+		var allPoints = new List<Vector3>();
 
-    private ArcGISPoint HitToGeoPosition(RaycastHit hit, float zOffset = 0)
-    {
-        var worldPosition = math.inverse(arcGISMapComponent.WorldMatrix).HomogeneousTransformPoint(hit.point.ToDouble3());
+		foreach (var stop in featurePoints)
+		{
+			if (stop.transform.position.Equals(Vector3.zero))
+			{
+				Destroy(stop);
+				continue;
+			}
+			allPoints.Add(stop.transform.position);
+		}
 
-        var geoPosition = arcGISMapComponent.View.WorldToGeographic(worldPosition);
-        return new ArcGISPoint(geoPosition.X, geoPosition.Y, geoPosition.Z + zOffset, geoPosition.SpatialReference);
+		lineRenderer.positionCount = allPoints.Count;
+		lineRenderer.SetPositions(allPoints.ToArray());
+	}
 
-    }
+	public void ClearLine()
+	{
+		foreach (var stop in featurePoints)
+			Destroy(stop);
+		featurePoints.Clear();
+		stops.Clear();
+		geodeticDistance = 0;
+		GeodeticDistanceText.text = "Distance: " + geodeticDistance + unitTxt;
+		if (lineRenderer)
+			lineRenderer.positionCount = 0;
 
-    // set height for point transform and location component
-    void SetElevation(GameObject stop)
-    {
-        // start the raycast in the air at an arbitrary to ensure it is above the ground
-        var raycastHeight = 5000;
-        var position = stop.transform.position;
-        var raycastStart = new Vector3(position.x, position.y + raycastHeight, position.z);
-        if (Physics.Raycast(raycastStart, Vector3.down, out RaycastHit hitInfo))
-        {
-            var location = stop.GetComponent<ArcGISLocationComponent>();
-            location.Position = HitToGeoPosition(hitInfo, elevationOffset);
-            stop.transform.position = hitInfo.point;
-        }
-    }
+	}
 
-    private void RenderLine(ref List<GameObject> featurePoints)
-    {
+	private void RebaseLine()
+	{
+		var rootPosition = arcGISMapComponent.GetComponent<HPRoot>().RootUniversePosition;
+		var delta = (lastRootPosition - rootPosition).ToVector3();
+		if (delta.magnitude > 1) // 1km
+		{
+			if (lineRenderer != null)
+			{
+				Vector3[] points = new Vector3[lineRenderer.positionCount];
+				lineRenderer.GetPositions(points);
+				for (int i = 0; i < points.Length; i++)
+				{
+					points[i] += delta;
+				}
+				lineRenderer.SetPositions(points);
+			}
+			lastRootPosition = rootPosition;
+		}
+	}
 
-        lineRenderer.widthMultiplier = 5;
-
-        var allPoints = new List<Vector3>();
-
-        foreach (var stop in featurePoints)
-        {
-            if (stop.transform.position.Equals(Vector3.zero))
-            {
-                Destroy(stop);
-                continue;
-            }
-            allPoints.Add(stop.transform.position);
-        }
-
-        lineRenderer.positionCount = allPoints.Count;
-        lineRenderer.SetPositions(allPoints.ToArray());
-    }
-
-    public void ClearLine()
-    {
-        foreach (var stop in featurePoints)
-            Destroy(stop);
-        featurePoints.Clear();
-        stops.Clear();
-        geodedicDistance = 0;
-        GeodedicDistanceText.text = "Distance: " + geodedicDistance + unitTxt;
-        if (lineRenderer)
-            lineRenderer.positionCount = 0;
-
-    }
-
-    private void RebaseLine()
-    {
-        var rootPosition = arcGISMapComponent.GetComponent<HPRoot>().RootUniversePosition;
-        var delta = (lastRootPosition - rootPosition).ToVector3();
-        if (delta.magnitude > 1) // 1km
-        {
-            if (lineRenderer != null)
-            {
-                Vector3[] points = new Vector3[lineRenderer.positionCount];
-                lineRenderer.GetPositions(points);
-                for (int i = 0; i < points.Length; i++)
-                {
-                    points[i] += delta;
-                }
-                lineRenderer.SetPositions(points);
-            }
-            lastRootPosition = rootPosition;
-        }
-    }
-
-    void UnitChanged()
-    {
-        if (UnitDropdown.options[UnitDropdown.value].text == "Meters")
-        {
-            ArcGISLinearUnitId unitM = (ArcGISLinearUnitId)9001;
-            unit = unitM;
-            geodedicDistance = ConvertUnits(geodedicDistance, currentUnit, UnitType.m);
-            currentUnit = UnitType.m;
-            unitTxt = " m";
-        }
-        else if (UnitDropdown.options[UnitDropdown.value].text == "Kilometers")
-        {
-            ArcGISLinearUnitId unitKm = (ArcGISLinearUnitId)9036;
-            unit = unitKm;
-            geodedicDistance = ConvertUnits(geodedicDistance, currentUnit, UnitType.km);
-            currentUnit = UnitType.km;
-            unitTxt = " km";
-        }
-        else if (UnitDropdown.options[UnitDropdown.value].text == "Miles")
-        {
-            ArcGISLinearUnitId unitMi = (ArcGISLinearUnitId)9093;
-            unit = unitMi;
-            geodedicDistance = ConvertUnits(geodedicDistance, currentUnit, UnitType.mi);
-            currentUnit = UnitType.mi;
-            unitTxt = " mi";
-        }
-        else if (UnitDropdown.options[UnitDropdown.value].text == "Feet")
-        {
-            ArcGISLinearUnitId unitFt = (ArcGISLinearUnitId)9002;
-            unit = unitFt;
-            geodedicDistance = ConvertUnits(geodedicDistance, currentUnit, UnitType.ft);
-            currentUnit = UnitType.ft;
-            unitTxt = " ft";
-        }
-        GeodedicDistanceText.text = "Distance: " + Math.Round(geodedicDistance, 3).ToString() + unitTxt;
-        //UnitDropdown.interactable=false;
-
-    }
-
-    public static double ConvertUnits(double units, UnitType from, UnitType to)
-    {
-        double[][] factor =
-        {
-            new double[] { 1, 0.001, 0.000621371, 3.28084 },
-            new double[] { 1000,   1,     0.621371,   3280.84},
-            new double[] { 1609.344,     1.609344,       1,   5280},
-            new double[] { 0.3048,    0.0003048,  0.00018939,    1}
-        };
-
-        return units * factor[(int)from][(int)to];
-    }
+	void UnitChanged()
+	{
+		if (UnitDropdown.options[UnitDropdown.value].text == "Meters")
+		{
+			geodeticDistance = currentUnit.ConvertTo(new ArcGISLinearUnit(ArcGISLinearUnitId.Meters), geodeticDistance);
+			currentUnit = new ArcGISLinearUnit(ArcGISLinearUnitId.Meters);
+			unitTxt = " m";
+		}
+		else if (UnitDropdown.options[UnitDropdown.value].text == "Kilometers")
+		{
+			geodeticDistance = currentUnit.ConvertTo(new ArcGISLinearUnit(ArcGISLinearUnitId.Kilometers), geodeticDistance);
+			currentUnit = new ArcGISLinearUnit(ArcGISLinearUnitId.Kilometers);
+			unitTxt = " km";
+		}
+		else if (UnitDropdown.options[UnitDropdown.value].text == "Miles")
+		{
+			geodeticDistance = currentUnit.ConvertTo(new ArcGISLinearUnit(ArcGISLinearUnitId.Miles), geodeticDistance);
+			currentUnit = new ArcGISLinearUnit(ArcGISLinearUnitId.Miles);
+			unitTxt = " mi";
+		}
+		else if (UnitDropdown.options[UnitDropdown.value].text == "Feet")
+		{
+			geodeticDistance = currentUnit.ConvertTo(new ArcGISLinearUnit(ArcGISLinearUnitId.Feet), geodeticDistance);
+			currentUnit = new ArcGISLinearUnit(ArcGISLinearUnitId.Feet);
+			unitTxt = " ft";
+		}
+		GeodeticDistanceText.text = "Distance: " + Math.Round(geodeticDistance, 3).ToString() + unitTxt;
+	}
 
 }

--- a/samples_project/Assets/SampleViewer/Samples/Measure/Measure.unity
+++ b/samples_project/Assets/SampleViewer/Samples/Measure/Measure.unity
@@ -498,6 +498,7 @@ MonoBehaviour:
   horizontalFov: 88.76051
   viewportSizeX: 878
   viewportSizeY: 518
+  qualityScalingFactor: 1
 --- !u!114 &150318286
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2191,7 +2192,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   Line: {fileID: 820472294}
-  GeodedicDistanceText: {fileID: 134436593}
+  GeodeticDistanceText: {fileID: 134436593}
   LineMarker: {fileID: 5022259574890728151, guid: 4a39d5da76a48014d93cc6059717dc44, type: 3}
   InterpolationMarker: {fileID: 8846720079027601179, guid: dcfd660509e86354896380205354f1e6, type: 3}
   InterpolationInterval: 100
@@ -2461,9 +2462,16 @@ MonoBehaviour:
   basemapAuthentication:
     ConfigurationIndex: -1
   elevation: https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer
-  enableExtent: 0
   elevationAuthentication:
     ConfigurationIndex: -1
+  elevationSources:
+  - Name: 
+    Type: 0
+    Source: https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer
+    IsEnabled: 1
+    Authentication:
+      ConfigurationIndex: -1
+  enableExtent: 0
   extent:
     GeographicCenter:
       x: 0
@@ -2489,6 +2497,7 @@ MonoBehaviour:
   RootChanged:
     m_PersistentCalls:
       m_Calls: []
+  version: 1
 --- !u!114 &1808036066
 MonoBehaviour:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
**Summary**

The measure sample works but there are some improvements that can be done to the backend:

- [x] Instead of create a method

```
private ArcGISPoint HitToGeoPosition(RaycastHit hit, float zOffset = 0)
    {
        var worldPosition = math.inverse(arcGISMapComponent.WorldMatrix).HomogeneousTransformPoint(hit.point.ToDouble3());

        var geoPosition = arcGISMapComponent.View.WorldToGeographic(worldPosition);
        return new ArcGISPoint(geoPosition.X, geoPosition.Y, geoPosition.Z + zOffset, geoPosition.SpatialReference);

    }
```

there's already a method to convert from unity world transform to geoposition

`var geoPosition = arcGISMapComponent.EngineToGeographic(hit.point);`

- [x] I implemented a linear unit conversion function but there's already a unit conversion method in the geometry API. I've been wanted to remove my unit conversion since it's such a trivial task that there's no need to implement it again. 

- [x] corrected a typo which is geodetic distance (not geodedic)



