### PR TITLE
Fix URP mode not loading in Measure and Stream Layer samples

### DIFF
--- a/samples_project/Assets/SampleViewer/Samples/Measure/Measure.unity
+++ b/samples_project/Assets/SampleViewer/Samples/Measure/Measure.unity
@@ -458,9 +458,9 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   position:
-    x: -122.47
-    y: 37.805
-    z: 880
+    x: 0
+    y: 0
+    z: 0
     SRWkid: 4326
   rotation:
     Heading: 321.15
@@ -506,7 +506,7 @@ MonoBehaviour:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 150318280}
-  m_Enabled: 1
+  m_Enabled: 0
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 23c1ce4fb46143f46bc5cb5224c934f6, type: 3}
   m_Name: 
@@ -1546,8 +1546,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   position:
-    x: 0.0000036396480764896792
-    y: -0.0000008269325127392866
+    x: 0
+    y: 0
     z: 0
     SRWkid: 4326
   rotation:
@@ -2484,9 +2484,9 @@ MonoBehaviour:
       y: 0
   layers: []
   originPosition:
-    x: -122.4783
-    y: 37.8199
-    z: 1300
+    x: 0
+    y: 0
+    z: 0
     SRWkid: 4326
   mapType: 1
   editorModeEnabled: 1

--- a/samples_project/Assets/SampleViewer/Samples/StreamLayer/StreamLayer.unity
+++ b/samples_project/Assets/SampleViewer/Samples/StreamLayer/StreamLayer.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 261.89948, g: 324.4541, b: 429.4325, a: 1}
+  m_IndirectSpecularColor: {r: 262.3369, g: 325.0498, b: 430.21924, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -591,9 +591,16 @@ MonoBehaviour:
   basemapAuthentication:
     ConfigurationIndex: -1
   elevation: https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer
-  enableExtent: 0
   elevationAuthentication:
     ConfigurationIndex: -1
+  elevationSources:
+  - Name: 
+    Type: 0
+    Source: https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer
+    IsEnabled: 1
+    Authentication:
+      ConfigurationIndex: -1
+  enableExtent: 0
   extent:
     GeographicCenter:
       x: 0
@@ -619,6 +626,7 @@ MonoBehaviour:
   RootChanged:
     m_PersistentCalls:
       m_Calls: []
+  version: 1
 --- !u!114 &521274803
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1335,6 +1343,7 @@ MonoBehaviour:
   horizontalFov: 0
   viewportSizeX: 0
   viewportSizeY: 0
+  qualityScalingFactor: 1
 --- !u!20 &1354401680
 Camera:
   m_ObjectHideFlags: 0
@@ -1426,7 +1435,7 @@ MonoBehaviour:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1354401675}
-  m_Enabled: 1
+  m_Enabled: 0
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 23c1ce4fb46143f46bc5cb5224c934f6, type: 3}
   m_Name: 


### PR DESCRIPTION
**Sample**

Measure and Stream Layer Samples

**Summary**

I spotted the same error when I switched to URP measure sample and URP stream layer sample. HDRP mode did not have this kind of problem. Only URP mode with measure and stream layer sample.

![image](https://github.com/Esri/arcgis-maps-sdk-unity-samples/assets/106696949/1580235c-0a6e-4890-810b-c94236ae66fc)

```
NullReferenceException: Object reference not set to an instance of an object
UnityEngine.Rendering.HighDefinition.FrameSettingsHistory.AggregateFrameSettings (UnityEngine.Rendering.HighDefinition.FrameSettings& aggregatedFrameSettings, UnityEngine.Camera camera, UnityEngine.Rendering.HighDefinition.HDAdditionalCameraData additionalData, UnityEngine.Rendering.HighDefinition.HDRenderPipelineAsset hdrpAsset, UnityEngine.Rendering.HighDefinition.HDRenderPipelineAsset defaultHdrpAsset) (at Library/PackageCache/com.unity.render-pipelines.high-definition@12.1.6/Runtime/RenderPipeline/Settings/FrameSettingsHistory.cs:133)
UnityEngine.Rendering.HighDefinition.HDAdditionalCameraData.OnEnable () (at Library/PackageCache/com.unity.render-pipelines.high-definition@12.1.6/Runtime/RenderPipeline/Camera/HDAdditionalCameraData.cs:696)
```

**Fix**

Disable "HD Additional Camera Data" script

![image](https://github.com/Esri/arcgis-maps-sdk-unity-samples/assets/106696949/922e6403-cd60-4215-8068-b0f0c2bcab55)


**Tests**

Win x64

**ArcGIS Maps SDK Version**

R1.2
