### PR TITLE
GItignore ArcGIS package directory when downloaded from Unity Registry

### DIFF
--- a/sample_project/.gitignore
+++ b/sample_project/.gitignore
@@ -65,7 +65,7 @@ crashlytics-build.properties
 
 # ArcGIS Maps SDK
 /[Aa]ssets/[Ss]amples/ArcGIS Maps SDK for Unity*
-
+Packages/com.esri.arcgis-maps-sdk/
 
 # Packed Addressables
 /[Aa]ssets/[Aa]ddressable[Aa]ssets[Dd]ata/*/*.bin*

--- a/xr_sample_project/.gitignore
+++ b/xr_sample_project/.gitignore
@@ -65,7 +65,7 @@ crashlytics-build.properties
 
 # ArcGIS Maps SDK
 /[Aa]ssets/[Ss]amples/ArcGIS Maps SDK for Unity*
-
+Packages/com.esri.arcgis-maps-sdk/
 
 # Packed Addressables
 /[Aa]ssets/[Aa]ddressable[Aa]ssets[Dd]ata/*/*.bin*


### PR DESCRIPTION

**Sample**

General gitignore for main project and xr project

**Summary**

Gitignore will now ignore arcgis package directory so it won't add it if downloaded via the registry. Previously when importing the plugin package through Unity Registry, git would identify all the files from the package as changes, which differs from how importing via tarball works, but this change will remedy that and no longer identify package files as changes when downloading from the registry.

**Tests**

Unity 2022.3.22f1

To test, open a fresh clone of the repo, and use the Unity registry to import the ArcGIS plugin. Check the changed files found in git to make sure it isn't importing hundreds of files from the Packages folder. It should resemble the screenshot but without the .gitignore change

![image](https://github.com/Esri/arcgis-maps-sdk-unity-samples/assets/171297336/877cccef-e52b-4f75-9e7f-e92eee16fef9)


**ArcGIS Maps SDK Version**

1.5.0