### PR TITLE
Fix route moving issue

### DIFF
--- a/sample_project/Assets/SampleViewer/Samples/Routing/RouteManager.cs
+++ b/sample_project/Assets/SampleViewer/Samples/Routing/RouteManager.cs
@@ -4,52 +4,51 @@
 // You may obtain a copy of the License at: http://www.apache.org/licenses/LICENSE-2.0
 //
 
-using System.Collections;
-using System.Collections.Generic;
 using System.Net.Http;
+using System.Collections;
 using System.Threading.Tasks;
+using System.Collections.Generic;
 
 using Esri.ArcGISMapsSDK.Components;
-using Esri.ArcGISMapsSDK.Samples.Components;
 using Esri.ArcGISMapsSDK.Utils.GeoCoord;
 using Esri.GameEngine.Geometry;
 using Esri.HPFramework;
 
-using Newtonsoft.Json.Linq;
 using UnityEngine;
-using UnityEngine.InputSystem;
-using Unity.Mathematics;
 using TMPro;
+
+using Newtonsoft.Json.Linq;
+using Unity.Mathematics;
+using Esri.ArcGISMapsSDK.Samples.Components;
+using UnityEngine.InputSystem;
 
 public class RouteManager : MonoBehaviour
 {
-	public string apiKey;
-	public GameObject Route;
-	public GameObject RouteBreadcrumb;
-	public GameObject RouteInfo;
 	public GameObject RouteMarker;
+	public GameObject RouteBreadcrumb;
+	public GameObject Route;
+	public GameObject RouteInfo;
+	public string apiKey;
 
 	[SerializeField] private TextMeshProUGUI InfoField;
 
-	private Animator animator;
-	private ArcGISCameraComponent arcGISCamera;
-	private ArcGISMapComponent arcGISMapComponent;
-	private List<GameObject> breadcrumbs = new List<GameObject>();
-	private HPTransform cameraTransform;
-	private HttpClient client = new HttpClient();
-	private float elevationOffset = 20.0f;
 	private HPRoot hpRoot;
-	private InputActions inputActions;
-	private bool isLeftShiftPressed;
-	private double3 lastCameraPosition;
-	private Quaternion lastCameraRotation;
-	double3 lastRootPosition;
-	private LineRenderer lineRenderer;
-	private List<GameObject> routeMarkers = new List<GameObject>();
+	private ArcGISMapComponent arcGISMapComponent;
+	private Animator animator;
+	private float elevationOffset = 20.0f;
+	private int StopCount = 2;
+	private Queue<GameObject> stops = new Queue<GameObject>();
 	private bool routing = false;
 	private string routingURL = "https://route-api.arcgis.com/arcgis/rest/services/World/Route/NAServer/Route_World/solve";
-	private Queue<GameObject> stops = new Queue<GameObject>();
-	private int StopCount = 2;
+	private List<GameObject> breadcrumbs = new List<GameObject>();
+	private List<GameObject> routeMarkers = new List<GameObject>();
+	private LineRenderer lineRenderer;
+	private HttpClient client = new HttpClient();
+
+	double3 lastRootPosition;
+
+	private InputActions inputActions;
+	private bool isLeftShiftPressed;
 
 	private void Awake()
     {
@@ -129,8 +128,6 @@ public class RouteManager : MonoBehaviour
                 }
             }
         }
-
-        RebaseRoute();
     }
 
     void Start()
@@ -147,11 +144,8 @@ public class RouteManager : MonoBehaviour
         lineRenderer = Route.GetComponent<LineRenderer>();
 
         lastRootPosition = arcGISMapComponent.GetComponent<HPRoot>().RootUniversePosition;
-    }
 
-	private void Update()
-	{
-        RebaseRoute();
+		arcGISMapComponent.RootChanged.AddListener(RebaseRoute);
 	}
 
 	/// <summary>

--- a/sample_project/Assets/SampleViewer/Samples/Routing/RouteManager.cs
+++ b/sample_project/Assets/SampleViewer/Samples/Routing/RouteManager.cs
@@ -70,13 +70,13 @@ public class RouteManager : MonoBehaviour
         inputActions.DrawingControls.LeftShift.performed -= ctx => OnLeftShift(true);
         inputActions.DrawingControls.LeftShift.canceled -= ctx => OnLeftShift(false);
 
-		if (arcGISMapComponent != null)
-		{
-			arcGISMapComponent.RootChanged.RemoveListener(RebaseRoute);
-		}
+        if (arcGISMapComponent != null)
+        {
+            arcGISMapComponent.RootChanged.RemoveListener(RebaseRoute);
+        }
 	}
 
-	private void OnLeftShift(bool isPressed)
+    private void OnLeftShift(bool isPressed)
     {
         isLeftShiftPressed = isPressed;
     }
@@ -150,7 +150,7 @@ public class RouteManager : MonoBehaviour
 
         lastRootPosition = arcGISMapComponent.GetComponent<HPRoot>().RootUniversePosition;
 
-		arcGISMapComponent.RootChanged.AddListener(RebaseRoute);
+        arcGISMapComponent.RootChanged.AddListener(RebaseRoute);
 	}
 
     /// <summary>

--- a/sample_project/Assets/SampleViewer/Samples/Routing/RouteManager.cs
+++ b/sample_project/Assets/SampleViewer/Samples/Routing/RouteManager.cs
@@ -74,7 +74,7 @@ public class RouteManager : MonoBehaviour
         {
             arcGISMapComponent.RootChanged.RemoveListener(RebaseRoute);
         }
-	}
+    }
 
     private void OnLeftShift(bool isPressed)
     {
@@ -151,7 +151,7 @@ public class RouteManager : MonoBehaviour
         lastRootPosition = arcGISMapComponent.GetComponent<HPRoot>().RootUniversePosition;
 
         arcGISMapComponent.RootChanged.AddListener(RebaseRoute);
-	}
+    }
 
     /// <summary>
     /// Return GeoPosition Based on RaycastHit; I.E. Where the user clicked in the Scene.

--- a/sample_project/Assets/SampleViewer/Samples/Routing/RouteManager.cs
+++ b/sample_project/Assets/SampleViewer/Samples/Routing/RouteManager.cs
@@ -24,33 +24,33 @@ using UnityEngine.InputSystem;
 
 public class RouteManager : MonoBehaviour
 {
-	public GameObject RouteMarker;
-	public GameObject RouteBreadcrumb;
-	public GameObject Route;
-	public GameObject RouteInfo;
-	public string apiKey;
+    public GameObject RouteMarker;
+    public GameObject RouteBreadcrumb;
+    public GameObject Route;
+    public GameObject RouteInfo;
+    public string apiKey;
 
-	[SerializeField] private TextMeshProUGUI InfoField;
+    [SerializeField] private TextMeshProUGUI InfoField;
 
-	private HPRoot hpRoot;
-	private ArcGISMapComponent arcGISMapComponent;
-	private Animator animator;
-	private float elevationOffset = 20.0f;
-	private int StopCount = 2;
-	private Queue<GameObject> stops = new Queue<GameObject>();
-	private bool routing = false;
-	private string routingURL = "https://route-api.arcgis.com/arcgis/rest/services/World/Route/NAServer/Route_World/solve";
-	private List<GameObject> breadcrumbs = new List<GameObject>();
-	private List<GameObject> routeMarkers = new List<GameObject>();
-	private LineRenderer lineRenderer;
-	private HttpClient client = new HttpClient();
+    private HPRoot hpRoot;
+    private ArcGISMapComponent arcGISMapComponent;
+    private Animator animator;
+    private float elevationOffset = 20.0f;
+    private int StopCount = 2;
+    private Queue<GameObject> stops = new Queue<GameObject>();
+    private bool routing = false;
+    private string routingURL = "https://route-api.arcgis.com/arcgis/rest/services/World/Route/NAServer/Route_World/solve";
+    private List<GameObject> breadcrumbs = new List<GameObject>();
+    private List<GameObject> routeMarkers = new List<GameObject>();
+    private LineRenderer lineRenderer;
+    private HttpClient client = new HttpClient();
 
-	double3 lastRootPosition;
+    double3 lastRootPosition;
 
-	private InputActions inputActions;
-	private bool isLeftShiftPressed;
+    private InputActions inputActions;
+    private bool isLeftShiftPressed;
 
-	private void Awake()
+    private void Awake()
     {
         inputActions = new InputActions();
     }
@@ -69,9 +69,14 @@ public class RouteManager : MonoBehaviour
         inputActions.DrawingControls.LeftClick.started -= OnLeftClickStart;
         inputActions.DrawingControls.LeftShift.performed -= ctx => OnLeftShift(true);
         inputActions.DrawingControls.LeftShift.canceled -= ctx => OnLeftShift(false);
-    }
 
-    private void OnLeftShift(bool isPressed)
+		if (arcGISMapComponent != null)
+		{
+			arcGISMapComponent.RootChanged.RemoveListener(RebaseRoute);
+		}
+	}
+
+	private void OnLeftShift(bool isPressed)
     {
         isLeftShiftPressed = isPressed;
     }
@@ -148,12 +153,12 @@ public class RouteManager : MonoBehaviour
 		arcGISMapComponent.RootChanged.AddListener(RebaseRoute);
 	}
 
-	/// <summary>
-	/// Return GeoPosition Based on RaycastHit; I.E. Where the user clicked in the Scene.
-	/// </summary>
-	/// <param name="hit"></param>
-	/// <returns></returns>
-	private ArcGISPoint HitToGeoPosition(RaycastHit hit, float yOffset = 0)
+    /// <summary>
+    /// Return GeoPosition Based on RaycastHit; I.E. Where the user clicked in the Scene.
+    /// </summary>
+    /// <param name="hit"></param>
+    /// <returns></returns>
+    private ArcGISPoint HitToGeoPosition(RaycastHit hit, float yOffset = 0)
     {
         var worldPosition = math.inverse(arcGISMapComponent.WorldMatrix).HomogeneousTransformPoint(hit.point.ToDouble3());
 


### PR DESCRIPTION
**Sample**

Fix the route moving issue in the routing sample.

**Summary**

- [x] Fix route moving issue
- [x] Sort namespace and variables alphabetically

Currently, in the routing sample, if you move the camera, the route starts moving. There are a couple of ways to fix this. The easiest is to call RebaseRoute in update, although this is called every frame. Could also fix it by detecting camera movement, which is every time when camera moves or rotates, call RebaseRoute. 

```
private double3 lastCameraPosition; 
private double3 lastCameraRotation; 

private HPTransform cameraTransform; 

void Update()
{
    if (cameraTransform != null && HasCameraMovedOrRotated())
    {
        RebaseRoute();
    }

    if (cameraTransform != null)
    {
        lastCameraPosition = cameraTransform.UniversePosition;
        lastCameraRotation = cameraTransform.UniverseRotation.ToEulerAngles(); 
    }
}

private bool HasCameraMovedOrRotated()
{
    bool positionChanged = !cameraTransform.UniversePosition.Equals(lastCameraPosition);
    bool rotationChanged = !cameraTransform.UniverseRotation.ToEulerAngles().Equals(lastCameraRotation);

    return positionChanged || rotationChanged;
}
```

However, I tested and found that when the camera is far from the route,  floating-point precision cause calculation problems with rendering small objects (like routes) due to Unity's double precision issue, this can be addressed by increasing how often rebase gets called. If we don't call it by frame, we could also call it every 0.2 second for example but I thought that's unnecessary. Therefore I'm using method 1.

Issue 2893, link omitted

**ArcGIS Maps SDK Version**

tested with 1.6
