### PR TITLE
bug fix: revert input mode to both

### DIFF
--- a/sample_project/ProjectSettings/ProjectSettings.asset
+++ b/sample_project/ProjectSettings/ProjectSettings.asset
@@ -897,7 +897,7 @@ PlayerSettings:
   hmiLogStartupTiming: 0
   hmiCpuConfiguration: 
   apiCompatibilityLevel: 6
-  activeInputHandler: 1
+  activeInputHandler: 2
   windowsGamepadBackendHint: 0
   cloudProjectId: 
   framebufferDepthMemorylessMode: 0


### PR DESCRIPTION
**Sample**

<!-- Outline what sample this PR is fixing/adding or mention if it is a sample viewer improvement -->
N/A
**Summary**

<!-- Write a concise description of the change for reviewers. The more reviewers the better -->
An input mode of both is still needed to not have errors in `1.6`.
**Tests**

<!-- Mention which devices this was tested with -->
N/A
**ArcGIS Maps SDK Version**

<!-- Mention what version of the Maps SDK was used to test/develop this code -->
1.6