### PR TITLE
bug fix: fix issue where UI canvasses aren't clickable

### DIFF
--- a/sample_project/Assets/SampleViewer/Samples/BuildingFilter/BuildingFilter.unity
+++ b/sample_project/Assets/SampleViewer/Samples/BuildingFilter/BuildingFilter.unity
@@ -2388,7 +2388,7 @@ Canvas:
   m_AdditionalShaderChannelsFlag: 25
   m_UpdateRectTransformForStandalone: 0
   m_SortingLayerID: 0
-  m_SortingOrder: 0
+  m_SortingOrder: 1
   m_TargetDisplay: 0
 --- !u!224 &702040958
 RectTransform:

--- a/sample_project/Assets/SampleViewer/Samples/FeatureLayer/FeatureLayer.unity
+++ b/sample_project/Assets/SampleViewer/Samples/FeatureLayer/FeatureLayer.unity
@@ -2343,7 +2343,7 @@ Canvas:
   m_AdditionalShaderChannelsFlag: 25
   m_UpdateRectTransformForStandalone: 0
   m_SortingLayerID: 0
-  m_SortingOrder: 0
+  m_SortingOrder: 1
   m_TargetDisplay: 0
 --- !u!224 &916334026
 RectTransform:

--- a/sample_project/Assets/SampleViewer/Samples/Geocoding/Geocoding.unity
+++ b/sample_project/Assets/SampleViewer/Samples/Geocoding/Geocoding.unity
@@ -2231,7 +2231,7 @@ Canvas:
   m_AdditionalShaderChannelsFlag: 25
   m_UpdateRectTransformForStandalone: 0
   m_SortingLayerID: 0
-  m_SortingOrder: 0
+  m_SortingOrder: 1
   m_TargetDisplay: 0
 --- !u!1 &6131246911239946082
 GameObject:

--- a/sample_project/Assets/SampleViewer/Samples/Geometry/Geometry.unity
+++ b/sample_project/Assets/SampleViewer/Samples/Geometry/Geometry.unity
@@ -4739,7 +4739,7 @@ Canvas:
   m_AdditionalShaderChannelsFlag: 25
   m_UpdateRectTransformForStandalone: 0
   m_SortingLayerID: 0
-  m_SortingOrder: 0
+  m_SortingOrder: 1
   m_TargetDisplay: 0
 --- !u!114 &8225324984385568677
 MonoBehaviour:

--- a/sample_project/Assets/SampleViewer/Samples/HitTest/Hit Test.unity
+++ b/sample_project/Assets/SampleViewer/Samples/HitTest/Hit Test.unity
@@ -215,7 +215,7 @@ Canvas:
   m_AdditionalShaderChannelsFlag: 25
   m_UpdateRectTransformForStandalone: 0
   m_SortingLayerID: 0
-  m_SortingOrder: 0
+  m_SortingOrder: 1
   m_TargetDisplay: 0
 --- !u!224 &8266804
 RectTransform:

--- a/sample_project/Assets/SampleViewer/Samples/LineOfSight/LineOfSight.unity
+++ b/sample_project/Assets/SampleViewer/Samples/LineOfSight/LineOfSight.unity
@@ -2991,7 +2991,7 @@ Canvas:
   m_AdditionalShaderChannelsFlag: 25
   m_UpdateRectTransformForStandalone: 0
   m_SortingLayerID: 0
-  m_SortingOrder: 0
+  m_SortingOrder: 1
   m_TargetDisplay: 0
 --- !u!224 &8395965910906821316
 RectTransform:

--- a/sample_project/Assets/SampleViewer/Samples/MaterialByAttribute/MaterialByAttribute.unity
+++ b/sample_project/Assets/SampleViewer/Samples/MaterialByAttribute/MaterialByAttribute.unity
@@ -921,7 +921,7 @@ Canvas:
   m_AdditionalShaderChannelsFlag: 25
   m_UpdateRectTransformForStandalone: 0
   m_SortingLayerID: 0
-  m_SortingOrder: 0
+  m_SortingOrder: 1
   m_TargetDisplay: 0
 --- !u!224 &635897889
 RectTransform:

--- a/sample_project/Assets/SampleViewer/Samples/Measure/Measure.unity
+++ b/sample_project/Assets/SampleViewer/Samples/Measure/Measure.unity
@@ -4014,7 +4014,7 @@ Canvas:
   m_AdditionalShaderChannelsFlag: 25
   m_UpdateRectTransformForStandalone: 0
   m_SortingLayerID: 0
-  m_SortingOrder: 0
+  m_SortingOrder: 1
   m_TargetDisplay: 0
 --- !u!114 &8225324984385568677
 MonoBehaviour:

--- a/sample_project/Assets/SampleViewer/Samples/Routing/Routing.unity
+++ b/sample_project/Assets/SampleViewer/Samples/Routing/Routing.unity
@@ -1898,7 +1898,7 @@ Canvas:
   m_AdditionalShaderChannelsFlag: 25
   m_UpdateRectTransformForStandalone: 0
   m_SortingLayerID: 0
-  m_SortingOrder: 0
+  m_SortingOrder: 1
   m_TargetDisplay: 0
 --- !u!114 &4406315854834080669
 MonoBehaviour:

--- a/sample_project/Assets/SampleViewer/Samples/StreamLayer/StreamLayer.unity
+++ b/sample_project/Assets/SampleViewer/Samples/StreamLayer/StreamLayer.unity
@@ -3105,7 +3105,7 @@ Canvas:
   m_AdditionalShaderChannelsFlag: 25
   m_UpdateRectTransformForStandalone: 0
   m_SortingLayerID: 0
-  m_SortingOrder: 0
+  m_SortingOrder: 1
   m_TargetDisplay: 0
 --- !u!114 &5238861767689048157
 MonoBehaviour:

--- a/sample_project/Assets/SampleViewer/Samples/ThirdPerson/ThirdPerson.unity
+++ b/sample_project/Assets/SampleViewer/Samples/ThirdPerson/ThirdPerson.unity
@@ -1983,7 +1983,7 @@ Canvas:
   m_AdditionalShaderChannelsFlag: 25
   m_UpdateRectTransformForStandalone: 0
   m_SortingLayerID: 0
-  m_SortingOrder: 0
+  m_SortingOrder: 1
   m_TargetDisplay: 0
 --- !u!210 &1541386278
 SortingGroup:

--- a/sample_project/Assets/SampleViewer/Samples/WeatherQuery/WeatherQuery.unity
+++ b/sample_project/Assets/SampleViewer/Samples/WeatherQuery/WeatherQuery.unity
@@ -3675,7 +3675,7 @@ Canvas:
   m_AdditionalShaderChannelsFlag: 25
   m_UpdateRectTransformForStandalone: 0
   m_SortingLayerID: 0
-  m_SortingOrder: 0
+  m_SortingOrder: 1
   m_TargetDisplay: 0
 --- !u!224 &1670182094
 RectTransform:


### PR DESCRIPTION
**Summary**

<!-- Write a concise description of the change for reviewers. The more reviewers the better -->
When running samples standalone, the attribution UI document overlaps the UI canvas for samples. Changing the sort order for the canvas works around this issue.

**Checklist**

<!--- Delete any that don't apply -->

- [x] PR title follows convention - `keyword: Short description of change` <!--- Example:  ansible: Update build scripts to handle new engine versions -->
- [x] PR targets the correct branch <!-- Changes going into `main` work with the current public release of the plugin-->
- [x] Self-review of changes
- [x] There are no warnings related to changes
- [ ] A build was made and tested on all relevant platforms
- [x] No unrelated changes have been made to any other code or project files
- [x] No unnecessary includes or namespaces added
- [x] Code follows plugin coding style
- [x] New code and changed code has proper formatting <!-- Run a formatter if unsure -->
- [x] No unintentional formatting changes
- [x] Commits have descriptive titles

**ArcGIS Maps SDK Version**

<!-- Mention what version of the Maps SDK was used to test/develop this code -->
1.7