### PR TITLE
Bug: Set Render Pipeline on level load from Sample veiwer

### DIFF
--- a/sample_project/Assets/SampleViewer/SampleViewer.unity
+++ b/sample_project/Assets/SampleViewer/SampleViewer.unity
@@ -470,16 +470,16 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 1
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: DisableTouchJoysticks, Sample Viewer
-        m_MethodName: ToggleCanvas
-        m_Mode: 6
+      - m_Target: {fileID: 1201840877}
+        m_TargetAssemblyTypeName: SampleSwitcher, Sample Viewer
+        m_MethodName: SetPipelineText
+        m_Mode: 5
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
           m_IntArgument: 0
           m_FloatArgument: 0
-          m_StringArgument: 
+          m_StringArgument: HDRP
           m_BoolArgument: 1
         m_CallState: 2
 --- !u!114 &25969154
@@ -4837,16 +4837,16 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 1
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: DisableTouchJoysticks, Sample Viewer
-        m_MethodName: ToggleCanvas
-        m_Mode: 6
+      - m_Target: {fileID: 1201840877}
+        m_TargetAssemblyTypeName: SampleSwitcher, Sample Viewer
+        m_MethodName: SetPipelineText
+        m_Mode: 5
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
           m_IntArgument: 0
           m_FloatArgument: 0
-          m_StringArgument: 
+          m_StringArgument: HDRP
           m_BoolArgument: 1
         m_CallState: 2
 --- !u!114 &820585088
@@ -5202,16 +5202,16 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: DisableTouchJoysticks, Sample Viewer
-        m_MethodName: ToggleCanvas
-        m_Mode: 6
+      - m_Target: {fileID: 1201840877}
+        m_TargetAssemblyTypeName: SampleSwitcher, Sample Viewer
+        m_MethodName: SetPipelineText
+        m_Mode: 5
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
           m_IntArgument: 0
           m_FloatArgument: 0
-          m_StringArgument: 
+          m_StringArgument: HDRP
           m_BoolArgument: 1
         m_CallState: 2
       - m_Target: {fileID: 1594867557}
@@ -5479,16 +5479,16 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 1
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: DisableTouchJoysticks, Sample Viewer
-        m_MethodName: ToggleCanvas
-        m_Mode: 6
+      - m_Target: {fileID: 1201840877}
+        m_TargetAssemblyTypeName: SampleSwitcher, Sample Viewer
+        m_MethodName: SetPipelineText
+        m_Mode: 5
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
           m_IntArgument: 0
           m_FloatArgument: 0
-          m_StringArgument: 
+          m_StringArgument: HDRP
           m_BoolArgument: 1
         m_CallState: 2
 --- !u!114 &966157426
@@ -5958,16 +5958,16 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 1
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: DisableTouchJoysticks, Sample Viewer
-        m_MethodName: ToggleCanvas
-        m_Mode: 6
+      - m_Target: {fileID: 1201840877}
+        m_TargetAssemblyTypeName: SampleSwitcher, Sample Viewer
+        m_MethodName: SetPipelineText
+        m_Mode: 5
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
           m_IntArgument: 0
           m_FloatArgument: 0
-          m_StringArgument: 
+          m_StringArgument: HDRP
           m_BoolArgument: 1
         m_CallState: 2
 --- !u!114 &1042277479
@@ -6886,16 +6886,16 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 1
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: DisableTouchJoysticks, Sample Viewer
-        m_MethodName: ToggleCanvas
-        m_Mode: 6
+      - m_Target: {fileID: 1201840877}
+        m_TargetAssemblyTypeName: SampleSwitcher, Sample Viewer
+        m_MethodName: SetPipelineText
+        m_Mode: 5
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
           m_IntArgument: 0
           m_FloatArgument: 0
-          m_StringArgument: 
+          m_StringArgument: HDRP
           m_BoolArgument: 1
         m_CallState: 2
 --- !u!114 &1217990429
@@ -7115,16 +7115,16 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 1
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: DisableTouchJoysticks, Sample Viewer
-        m_MethodName: ToggleCanvas
-        m_Mode: 6
+      - m_Target: {fileID: 1201840877}
+        m_TargetAssemblyTypeName: SampleSwitcher, Sample Viewer
+        m_MethodName: SetPipelineText
+        m_Mode: 5
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
           m_IntArgument: 0
           m_FloatArgument: 0
-          m_StringArgument: 
+          m_StringArgument: HDRP
           m_BoolArgument: 1
         m_CallState: 2
 --- !u!114 &1234668031
@@ -7553,16 +7553,16 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 1
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: DisableTouchJoysticks, Sample Viewer
-        m_MethodName: ToggleCanvas
-        m_Mode: 6
+      - m_Target: {fileID: 1201840877}
+        m_TargetAssemblyTypeName: SampleSwitcher, Sample Viewer
+        m_MethodName: SetPipelineText
+        m_Mode: 5
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
           m_IntArgument: 0
           m_FloatArgument: 0
-          m_StringArgument: 
+          m_StringArgument: HDRP
           m_BoolArgument: 1
         m_CallState: 2
 --- !u!114 &1305674606
@@ -7952,16 +7952,16 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 1
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: DisableTouchJoysticks, Sample Viewer
-        m_MethodName: ToggleCanvas
-        m_Mode: 6
+      - m_Target: {fileID: 1201840877}
+        m_TargetAssemblyTypeName: SampleSwitcher, Sample Viewer
+        m_MethodName: SetPipelineText
+        m_Mode: 5
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
           m_IntArgument: 0
           m_FloatArgument: 0
-          m_StringArgument: 
+          m_StringArgument: HDRP
           m_BoolArgument: 1
         m_CallState: 2
 --- !u!114 &1492081637
@@ -8688,16 +8688,16 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 1
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: DisableTouchJoysticks, Sample Viewer
-        m_MethodName: ToggleCanvas
-        m_Mode: 6
+      - m_Target: {fileID: 1201840877}
+        m_TargetAssemblyTypeName: SampleSwitcher, Sample Viewer
+        m_MethodName: SetPipelineText
+        m_Mode: 5
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
           m_IntArgument: 0
           m_FloatArgument: 0
-          m_StringArgument: 
+          m_StringArgument: HDRP
           m_BoolArgument: 1
         m_CallState: 2
 --- !u!114 &1550334601
@@ -9598,16 +9598,16 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 1
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: DisableTouchJoysticks, Sample Viewer
-        m_MethodName: ToggleCanvas
-        m_Mode: 6
+      - m_Target: {fileID: 1201840877}
+        m_TargetAssemblyTypeName: SampleSwitcher, Sample Viewer
+        m_MethodName: SetPipelineText
+        m_Mode: 5
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
           m_IntArgument: 0
           m_FloatArgument: 0
-          m_StringArgument: 
+          m_StringArgument: HDRP
           m_BoolArgument: 1
         m_CallState: 2
 --- !u!114 &1641010509
@@ -10071,16 +10071,16 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 1
         m_CallState: 2
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: DisableTouchJoysticks, Sample Viewer
-        m_MethodName: ToggleCanvas
-        m_Mode: 6
+      - m_Target: {fileID: 1201840877}
+        m_TargetAssemblyTypeName: SampleSwitcher, Sample Viewer
+        m_MethodName: SetPipelineText
+        m_Mode: 5
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
           m_IntArgument: 0
           m_FloatArgument: 0
-          m_StringArgument: 
+          m_StringArgument: HDRP
           m_BoolArgument: 1
         m_CallState: 2
 --- !u!114 &1850605298


### PR DESCRIPTION
**Sample**

Specific to the weather sample but absent from all samples in sample viewer. When loading a level it should set the HDRP Pipeline as the active pipeline. This event trigger was absent from all scene buttons in sample viewer. This PR adds it back to all buttons in Sample Viewer

**Checklist**

<!--- Delete any that don't apply -->

- [x] PR title follows convention - `keyword: Short description of change` <!--- Example:  ansible: Update build scripts to handle new engine versions -->
- [x] PR targets the correct branch <!-- Changes going into `main` work with the current public release of the plugin-->
- [x] Self-review of changes
- [x] There are no warnings related to changes
- [ ] A build was made and tested on all relevant platforms
- [x] No unrelated changes have been made to any other code or project files
- [x] No unnecessary includes or namespaces added
- [x] Code follows plugin coding style
- [x] New code and changed code has proper formatting <!-- Run a formatter if unsure -->
- [x] No unintentional formatting changes
- [x] Commits have descriptive titles

**ArcGIS Maps SDK Version**

maps SDK 1.7 W/ Unity 2022.3
