### PR TITLE
bug fix: make API key warning disappear and adjust tooltip size.

### DIFF
--- a/sample_project/Assets/SampleViewer/Resources/Prefabs/TooltipPanel.prefab
+++ b/sample_project/Assets/SampleViewer/Resources/Prefabs/TooltipPanel.prefab
@@ -34,11 +34,10 @@ RectTransform:
   m_Children:
   - {fileID: 5522848969699955612}
   m_Father: {fileID: 5522848968938192203}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 1933, y: -321}
+  m_AnchoredPosition: {x: 1400, y: -321}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &5522848968209379384
@@ -149,7 +148,6 @@ RectTransform:
   m_Children:
   - {fileID: 5522848968209379364}
   m_Father: {fileID: 0}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -233,11 +231,10 @@ RectTransform:
   m_GameObject: {fileID: 5522848969699955611}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
+  m_LocalScale: {x: 2, y: 2, z: 2}
+  m_ConstrainProportionsScale: 1
   m_Children: []
   m_Father: {fileID: 5522848968209379364}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -299,8 +296,8 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 40
-  m_fontSizeBase: 40
+  m_fontSize: 50
+  m_fontSizeBase: 50
   m_fontWeight: 400
   m_enableAutoSizing: 0
   m_fontSizeMin: 18

--- a/sample_project/Assets/SampleViewer/Scripts/SampleSwitcher.cs
+++ b/sample_project/Assets/SampleViewer/Scripts/SampleSwitcher.cs
@@ -187,19 +187,14 @@ public class SampleSwitcher : MonoBehaviour
         apiKey = value;
         apiKeyInputField.text = string.IsNullOrEmpty(apiKey) ? "Enter your API key here..." : apiKey;
 
-        if (warning != null)
-        {
-            return;
-        }
-
         if (string.IsNullOrEmpty(apiKey))
         {
-            warning.gameObject.SetActive(true);
+            warning?.gameObject?.SetActive(true);
             DisableSceneButtons();
         }
         else
         {
-            warning.gameObject.SetActive(false);
+            warning?.gameObject?.SetActive(false);
             EnableSceneButtons();
         }
     }


### PR DESCRIPTION
**Summary**

This fixes two issues related to the API key warning.

1. Tooltip text is now larger and readable.
2. Warning disappears after entering API key.

**Checklist**

<!--- Delete any that don't apply -->

- [x] PR title follows convention - `keyword: Short description of change` <!--- Example:  ansible: Update build scripts to handle new engine versions -->
- [x] PR targets the correct branch <!-- Changes going into `main` work with the current public release of the plugin-->
- [x] Self-review of changes
- [x] There are no warnings related to changes
- [ ] A build was made and tested on all relevant platforms
- [x] No unrelated changes have been made to any other code or project files
- [x] No unnecessary includes or namespaces added
- [x] Code follows plugin coding style
- [x] New code and changed code has proper formatting <!-- Run a formatter if unsure -->
- [x] No unintentional formatting changes
- [x] Commits have descriptive titles

**ArcGIS Maps SDK Version**

<!-- Mention what version of the Maps SDK was used to test/develop this code -->
1.7