### PR TITLE
bug fix: Add sampleswitcher code for setting API key on ViewshedMap

### DIFF
--- a/sample_project/Assets/SampleViewer/Samples/Viewshed/Scripts/ViewshedMap.cs
+++ b/sample_project/Assets/SampleViewer/Samples/Viewshed/Scripts/ViewshedMap.cs
@@ -14,6 +14,7 @@ using System.Collections;
 public class ViewshedMap : MonoBehaviour
 {
     [SerializeField] private Material viewshedMaterial;
+    public string APIKey = "";
 
     private IEnumerator Start()
     {
@@ -21,21 +22,19 @@ public class ViewshedMap : MonoBehaviour
 
         var mapComponent = FindFirstObjectByType<ArcGISMapComponent>();
 
-        var apiKey = "";
-
-        if (string.IsNullOrEmpty(apiKey))
+        if (string.IsNullOrEmpty(APIKey))
         {
-            apiKey = ArcGISProjectSettingsAsset.Instance.APIKey;
+            APIKey = ArcGISProjectSettingsAsset.Instance.APIKey;
         }
 
-        if (string.IsNullOrEmpty(apiKey))
+        if (string.IsNullOrEmpty(APIKey))
         {
             Debug.LogError("An API Key must be set on the SampleAPIMapCreator or in the project settings for content to load");
         }
 
         var map = new Esri.GameEngine.Map.ArcGISMap(mapComponent.MapType);
 
-        map.Basemap = new Esri.GameEngine.Map.ArcGISBasemap(Esri.GameEngine.Map.ArcGISBasemapStyle.ArcGISImagery, apiKey);
+        map.Basemap = new Esri.GameEngine.Map.ArcGISBasemap(Esri.GameEngine.Map.ArcGISBasemapStyle.ArcGISImagery, APIKey);
 
         map.Elevation = new Esri.GameEngine.Map.ArcGISMapElevation(new Esri.GameEngine.Elevation.ArcGISImageElevationSource("https://elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer", "Terrain 3D", ""));
 

--- a/sample_project/Assets/SampleViewer/Scripts/SampleSwitcher.cs
+++ b/sample_project/Assets/SampleViewer/Scripts/SampleSwitcher.cs
@@ -70,14 +70,18 @@ public class SampleSwitcher : MonoBehaviour
 
     private void ApplyApiKey()
     {
-        // API Script handles api key differently than the mapcomponent
-        var api = FindObjectOfType<APIMapCreator>();
-        if (api != null)
+        // API scripts handle api key differently than mapcomponent.
+        var apiMapCreator = FindObjectOfType<APIMapCreator>();
+        var viewShedMapCreator = FindObjectOfType<ViewshedMap>();
+
+        if (apiMapCreator != null && string.IsNullOrEmpty(apiMapCreator.APIKey))
         {
-            if (api.APIKey == "")
-            {
-                api.APIKey = apiKey;
-            }
+            apiMapCreator.APIKey = apiKey;
+            return;
+        }
+        else if (viewShedMapCreator != null && string.IsNullOrEmpty(viewShedMapCreator.APIKey))
+        {
+            viewShedMapCreator.APIKey = apiKey;
             return;
         }
 


### PR DESCRIPTION
**Summary**

<!-- Write a concise description of the change for reviewers. The more reviewers the better -->
Viewshed Map sample had a case where an API key would not be set if the user had entered the key into the viewer and not the project settings.

I added additional code to the SampleSwitcher matching the pattern in place for `APIMapCreator`.

**Checklist**

<!--- Delete any that don't apply -->

- [x] PR title follows convention - `keyword: Short description of change` <!--- Example:  ansible: Update build scripts to handle new engine versions -->
- [x] PR targets the correct branch <!-- Changes going into `main` work with the current public release of the plugin-->
- [x] Self-review of changes
- [x] There are no warnings related to changes
- [x] A build was made and tested on all relevant platforms
- [x] No unrelated changes have been made to any other code or project files
- [x] No unnecessary includes or namespaces added
- [x] Code follows plugin coding style
- [x] New code and changed code has proper formatting <!-- Run a formatter if unsure -->
- [x] No unintentional formatting changes
- [x] Commits have descriptive titles

**ArcGIS Maps SDK Version**

<!-- Mention what version of the Maps SDK was used to test/develop this code -->
1.7