### PR TITLE
Bug: Disable Fog in Weather Sample

### DIFF
--- a/sample_project/Assets/SampleViewer/Samples/WeatherQuery/Sky/Sky and Fog Settings 2.asset
+++ b/sample_project/Assets/SampleViewer/Samples/WeatherQuery/Sky/Sky and Fog Settings 2.asset
@@ -513,7 +513,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 953beb541740ddc499d005ee80c9ff29, type: 3}
   m_Name: Fog
   m_EditorClassIdentifier: 
-  active: 1
+  active: 0
   quality:
     m_OverrideState: 0
     m_Value: 1


### PR DESCRIPTION
**Sample**

Weather Sample
Base maps would appear to not show up in the weather sample. After some research this was an issue only in Unity 6 when the fog was enabled for the Sky Atmosphere. Disabling it fixes the issue and does not affect Unity 2022. Weather sample now works in both Unity 6 and Unity 2022

**Checklist**

<!--- Delete any that don't apply -->

- [x] PR title follows convention - `keyword: Short description of change` <!--- Example:  ansible: Update build scripts to handle new engine versions -->
- [x] PR targets the correct branch <!-- Changes going into `main` work with the current public release of the plugin-->
- [x] Self-review of changes
- [x] There are no warnings related to changes
- [x] A build was made and tested on all relevant platforms
- [x] No unrelated changes have been made to any other code or project files
- [x] No unnecessary includes or namespaces added
- [x] Code follows plugin coding style
- [x] New code and changed code has proper formatting <!-- Run a formatter if unsure -->
- [x] No unintentional formatting changes
- [x] Commits have descriptive titles

**ArcGIS Maps SDK Version**

Maps SDK 1.7 w/Unity 2022 LTS & Unity 6 LTS
