### PR TITLE
PCL: move map origin close to layer + minor improvements

### DIFF
--- a/sample_project/Assets/SampleViewer/Samples/PointCloudLayer/PointCloudLayer.unity
+++ b/sample_project/Assets/SampleViewer/Samples/PointCloudLayer/PointCloudLayer.unity
@@ -13,7 +13,7 @@ OcclusionCullingSettings:
 --- !u!104 &2
 RenderSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 9
+  serializedVersion: 10
   m_Fog: 0
   m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
   m_FogMode: 3
@@ -42,8 +42,8 @@ RenderSettings:
 --- !u!157 &3
 LightmapSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 12
-  m_GIWorkflowMode: 1
+  serializedVersion: 13
+  m_BakeOnSceneLoad: 0
   m_GISettings:
     serializedVersion: 2
     m_BounceScale: 1
@@ -66,9 +66,6 @@ LightmapSettings:
     m_LightmapParameters: {fileID: 0}
     m_LightmapsBakeMode: 1
     m_TextureCompression: 1
-    m_FinalGather: 0
-    m_FinalGatherFiltering: 1
-    m_FinalGatherRayCount: 256
     m_ReflectionCompression: 2
     m_MixedBakeMode: 2
     m_BakeBackend: 1
@@ -155,6 +152,7 @@ MonoBehaviour:
   m_StaticLightingSkyUniqueID: 0
   m_StaticLightingCloudsUniqueID: 0
   m_StaticLightingVolumetricClouds: 0
+  bounces: 1
 --- !u!4 &69324442
 Transform:
   m_ObjectHideFlags: 1
@@ -404,11 +402,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d5ee884efaf64db4bb2df363dd85cd0b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  toggle: {fileID: 83767727}
+  normalSprite: {fileID: 21300000, guid: 7e4ada0d78e46b647a21d9bd5107e801, type: 3}
+  selectedSprite: {fileID: 21300000, guid: a64d6b37677d4f7d9e7cfa52c9f86d6b, type: 3}
   targetImages:
   - {fileID: 1676704399}
-  selectedSprite: {fileID: 21300000, guid: a64d6b37677d4f7d9e7cfa52c9f86d6b, type: 3}
-  normalSprite: {fileID: 21300000, guid: 7e4ada0d78e46b647a21d9bd5107e801, type: 3}
+  toggle: {fileID: 83767727}
 --- !u!1 &120722120
 GameObject:
   m_ObjectHideFlags: 0
@@ -559,7 +557,7 @@ Transform:
   m_GameObject: {fileID: 150318280}
   serializedVersion: 2
   m_LocalRotation: {x: 0.20735544, y: -0.32442114, z: 0.073048376, w: 0.9200101}
-  m_LocalPosition: {x: 923.9518, y: -420, z: -2099.5122}
+  m_LocalPosition: {x: -5382745.5, y: 880, z: -282116.16}
   m_LocalScale: {x: 1.0000001, y: 1.0000001, z: 1.0000001}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -577,6 +575,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9e295d62bf65a7247bc772a43507fd4c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  isInitialized: 1
   position:
     X: -122.47
     Y: 37.805
@@ -593,7 +592,6 @@ MonoBehaviour:
   surfacePlacementMode: 0
   surfacePlacementOffset: 0
   version: 1
-  isInitialized: 1
 --- !u!114 &150318284
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -642,76 +640,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 23c1ce4fb46143f46bc5cb5224c934f6, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  clearColorMode: 0
-  backgroundColorHDR: {r: 0.025, g: 0.07, b: 0.19, a: 0}
-  clearDepth: 1
-  volumeLayerMask:
-    serializedVersion: 2
-    m_Bits: 1
-  volumeAnchorOverride: {fileID: 0}
-  antialiasing: 0
-  SMAAQuality: 2
-  dithering: 0
-  stopNaNs: 0
-  taaSharpenStrength: 0.5
-  TAAQuality: 1
-  taaHistorySharpening: 0.35
-  taaAntiFlicker: 0.5
-  taaMotionVectorRejection: 0
-  taaAntiHistoryRinging: 0
-  taaBaseBlendFactor: 0.875
-  taaJitterScale: 1
-  physicalParameters:
-    m_Iso: 200
-    m_ShutterSpeed: 0.005
-    m_Aperture: 16
-    m_FocusDistance: 10
-    m_BladeCount: 5
-    m_Curvature: {x: 2, y: 11}
-    m_BarrelClipping: 0.25
-    m_Anamorphism: 0
-  flipYMode: 0
-  xrRendering: 1
-  fullscreenPassthrough: 0
-  allowDynamicResolution: 0
-  customRenderingSettings: 0
-  invertFaceCulling: 0
-  probeLayerMask:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  hasPersistentHistory: 0
-  screenSizeOverride: {x: 0, y: 0, z: 0, w: 0}
-  screenCoordScaleBias: {x: 0, y: 0, z: 0, w: 0}
-  allowDeepLearningSuperSampling: 1
-  deepLearningSuperSamplingUseCustomQualitySettings: 0
-  deepLearningSuperSamplingQuality: 0
-  deepLearningSuperSamplingUseCustomAttributes: 0
-  deepLearningSuperSamplingUseOptimalSettings: 1
-  deepLearningSuperSamplingSharpening: 0
-  fsrOverrideSharpness: 0
-  fsrSharpness: 0.92
-  exposureTarget: {fileID: 0}
-  materialMipBias: 0
-  m_RenderingPathCustomFrameSettings:
-    bitDatas:
-      data1: 140666587840333
-      data2: 13763000512783810584
-    lodBias: 1
-    lodBiasMode: 0
-    lodBiasQualityLevel: 0
-    maximumLODLevel: 0
-    maximumLODLevelMode: 0
-    maximumLODLevelQualityLevel: 0
-    sssQualityMode: 0
-    sssQualityLevel: 0
-    sssCustomSampleBudget: 20
-    msaaMode: 1
-    materialQuality: 0
-  renderingPathCustomFrameSettingsOverrideMask:
-    mask:
-      data1: 0
-      data2: 0
-  defaultFrameSettings: 0
   m_Version: 9
   m_ObsoleteRenderingPath: 0
   m_ObsoleteFrameSettings:
@@ -759,6 +687,86 @@ MonoBehaviour:
       enableFptlForForwardOpaque: 0
       enableBigTilePrepass: 0
       isFptlEnabled: 0
+  clearColorMode: 0
+  backgroundColorHDR: {r: 0.025, g: 0.07, b: 0.19, a: 0}
+  clearDepth: 1
+  volumeLayerMask:
+    serializedVersion: 2
+    m_Bits: 1
+  volumeAnchorOverride: {fileID: 0}
+  antialiasing: 0
+  SMAAQuality: 2
+  dithering: 0
+  stopNaNs: 0
+  taaSharpenStrength: 0.5
+  TAAQuality: 1
+  taaSharpenMode: 0
+  taaRingingReduction: 0
+  taaHistorySharpening: 0.35
+  taaAntiFlicker: 0.5
+  taaMotionVectorRejection: 0
+  taaAntiHistoryRinging: 0
+  taaBaseBlendFactor: 0.875
+  taaJitterScale: 1
+  physicalParameters:
+    m_Iso: 200
+    m_ShutterSpeed: 0.005
+    m_Aperture: 16
+    m_FocusDistance: 10
+    m_BladeCount: 5
+    m_Curvature: {x: 2, y: 11}
+    m_BarrelClipping: 0.25
+    m_Anamorphism: 0
+  flipYMode: 0
+  xrRendering: 1
+  fullscreenPassthrough: 0
+  allowDynamicResolution: 0
+  customRenderingSettings: 0
+  invertFaceCulling: 0
+  probeLayerMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  hasPersistentHistory: 0
+  screenSizeOverride: {x: 0, y: 0, z: 0, w: 0}
+  screenCoordScaleBias: {x: 0, y: 0, z: 0, w: 0}
+  allowDeepLearningSuperSampling: 1
+  deepLearningSuperSamplingUseCustomQualitySettings: 0
+  deepLearningSuperSamplingQuality: 0
+  deepLearningSuperSamplingUseCustomAttributes: 0
+  deepLearningSuperSamplingUseOptimalSettings: 1
+  deepLearningSuperSamplingSharpening: 0
+  allowFidelityFX2SuperResolution: 1
+  fidelityFX2SuperResolutionUseCustomQualitySettings: 0
+  fidelityFX2SuperResolutionQuality: 0
+  fidelityFX2SuperResolutionUseCustomAttributes: 0
+  fidelityFX2SuperResolutionUseOptimalSettings: 1
+  fidelityFX2SuperResolutionEnableSharpening: 0
+  fidelityFX2SuperResolutionSharpening: 0
+  fsrOverrideSharpness: 0
+  fsrSharpness: 0.92
+  exposureTarget: {fileID: 0}
+  materialMipBias: 0
+  m_RenderingPathCustomFrameSettings:
+    bitDatas:
+      data1: 140666587840333
+      data2: 13763000512783810584
+    lodBias: 1
+    lodBiasMode: 0
+    lodBiasQualityLevel: 0
+    maximumLODLevel: 0
+    maximumLODLevelMode: 0
+    maximumLODLevelQualityLevel: 0
+    sssQualityMode: 0
+    sssQualityLevel: 0
+    sssCustomSampleBudget: 20
+    sssCustomDownsampleSteps: 0
+    msaaMode: 1
+    materialQuality: 0
+  renderingPathCustomFrameSettingsOverrideMask:
+    mask:
+      data1: 0
+      data2: 0
+  defaultFrameSettings: 0
 --- !u!81 &150318287
 AudioListener:
   m_ObjectHideFlags: 0
@@ -1008,20 +1016,23 @@ MonoBehaviour:
   m_VerticalAlignment: 256
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
   m_paragraphSpacing: 0
   m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 0
+  m_TextWrappingMode: 0
   m_wordWrappingRatios: 0.4
   m_overflowMode: 0
   m_linkedTextComponent: {fileID: 0}
   parentLinkedComponent: {fileID: 0}
   m_enableKerning: 1
+  m_ActiveFontFeatures: 6e72656b
   m_enableExtraPadding: 0
   checkPaddingRequired: 0
   m_isRichText: 1
+  m_EmojiFallbackSupport: 1
   m_parseCtrlCharacters: 1
   m_isOrthographic: 1
   m_isCullingEnabled: 0
@@ -1207,12 +1218,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d5ee884efaf64db4bb2df363dd85cd0b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  toggle: {fileID: 379465458}
+  normalSprite: {fileID: 21300000, guid: 4ecf96faddb843d4eb058b8f36a5c04e, type: 3}
+  selectedSprite: {fileID: 21300000, guid: b78ff50652f944a49bb0a63e861ecbf2, type: 3}
   targetImages:
   - {fileID: 379465459}
   - {fileID: 1221545976}
-  selectedSprite: {fileID: 21300000, guid: b78ff50652f944a49bb0a63e861ecbf2, type: 3}
-  normalSprite: {fileID: 21300000, guid: 4ecf96faddb843d4eb058b8f36a5c04e, type: 3}
+  toggle: {fileID: 379465458}
 --- !u!1001 &400085891
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1629,200 +1640,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 772269727}
   m_CullTransparentMesh: 1
---- !u!1 &820472294
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 820472295}
-  - component: {fileID: 820472298}
-  - component: {fileID: 820472297}
-  - component: {fileID: 820472296}
-  m_Layer: 0
-  m_Name: Line
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &820472295
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 820472294}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.70710677, y: -0, z: -0, w: 0.7071068}
-  m_LocalPosition: {x: 13634222, y: -1300, z: -4554015}
-  m_LocalScale: {x: 10, y: 10, z: 10}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1808036064}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!120 &820472296
-LineRenderer:
-  serializedVersion: 2
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 820472294}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 0
-  m_LightProbeUsage: 0
-  m_ReflectionProbeUsage: 0
-  m_RayTracingMode: 0
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 257
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: ca54e15eadab1d241b5120669ed50fd2, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_Positions:
-  - {x: 0, y: 0, z: 0}
-  - {x: 0, y: 0, z: 3}
-  m_Parameters:
-    serializedVersion: 3
-    widthMultiplier: 1
-    widthCurve:
-      serializedVersion: 2
-      m_Curve:
-      - serializedVersion: 3
-        time: 0
-        value: 1
-        inSlope: 0
-        outSlope: 0
-        tangentMode: 0
-        weightedMode: 0
-        inWeight: 0.33333334
-        outWeight: 0.33333334
-      m_PreInfinity: 2
-      m_PostInfinity: 2
-      m_RotationOrder: 4
-    colorGradient:
-      serializedVersion: 2
-      key0: {r: 1, g: 1, b: 1, a: 1}
-      key1: {r: 1, g: 1, b: 1, a: 1}
-      key2: {r: 0, g: 0, b: 0, a: 0}
-      key3: {r: 0, g: 0, b: 0, a: 0}
-      key4: {r: 0, g: 0, b: 0, a: 0}
-      key5: {r: 0, g: 0, b: 0, a: 0}
-      key6: {r: 0, g: 0, b: 0, a: 0}
-      key7: {r: 0, g: 0, b: 0, a: 0}
-      ctime0: 0
-      ctime1: 65535
-      ctime2: 0
-      ctime3: 0
-      ctime4: 0
-      ctime5: 0
-      ctime6: 0
-      ctime7: 0
-      atime0: 0
-      atime1: 65535
-      atime2: 0
-      atime3: 0
-      atime4: 0
-      atime5: 0
-      atime6: 0
-      atime7: 0
-      m_Mode: 0
-      m_ColorSpace: -1
-      m_NumColorKeys: 2
-      m_NumAlphaKeys: 2
-    numCornerVertices: 0
-    numCapVertices: 0
-    alignment: 0
-    textureMode: 0
-    textureScale: {x: 1, y: 1}
-    shadowBias: 0.5
-    generateLightingData: 0
-  m_MaskInteraction: 0
-  m_UseWorldSpace: 1
-  m_Loop: 0
-  m_ApplyActiveColorSpace: 0
---- !u!114 &820472297
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 820472294}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 9e295d62bf65a7247bc772a43507fd4c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  position:
-    X: 0
-    Y: 0
-    Z: 0
-    SRWkid: 4326
-    SpatialReference:
-      WKID: 4326
-      VerticalWKID: 0
-    version: 1
-  rotation:
-    Heading: 0
-    Pitch: 0
-    Roll: 0
-  surfacePlacementMode: 0
-  surfacePlacementOffset: 0
-  version: 1
-  isInitialized: 1
---- !u!114 &820472298
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 820472294}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: ea4c056ecab070c43bf3f5e9fb15b826, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_IsInitialized: 1
-  m_LocalPosition:
-    x: 0
-    y: 0
-    z: -0.0000000007081154551613622
-  m_LocalRotation:
-    value:
-      x: 0.70710677
-      y: 0
-      z: 0
-      w: 0.70710677
-  m_LocalScale:
-    x: 10
-    y: 10
-    z: 10
 --- !u!1 &843893029
 GameObject:
   m_ObjectHideFlags: 0
@@ -2154,20 +1971,23 @@ MonoBehaviour:
   m_VerticalAlignment: 256
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
   m_paragraphSpacing: 0
   m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 0
+  m_TextWrappingMode: 0
   m_wordWrappingRatios: 0.4
   m_overflowMode: 0
   m_linkedTextComponent: {fileID: 0}
   parentLinkedComponent: {fileID: 0}
   m_enableKerning: 1
+  m_ActiveFontFeatures: 6e72656b
   m_enableExtraPadding: 0
   checkPaddingRequired: 0
   m_isRichText: 1
+  m_EmojiFallbackSupport: 1
   m_parseCtrlCharacters: 1
   m_isOrthographic: 1
   m_isCullingEnabled: 0
@@ -2288,20 +2108,23 @@ MonoBehaviour:
   m_VerticalAlignment: 256
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
   m_paragraphSpacing: 0
   m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 0
+  m_TextWrappingMode: 0
   m_wordWrappingRatios: 0.4
   m_overflowMode: 0
   m_linkedTextComponent: {fileID: 0}
   parentLinkedComponent: {fileID: 0}
   m_enableKerning: 1
+  m_ActiveFontFeatures: 6e72656b
   m_enableExtraPadding: 0
   checkPaddingRequired: 0
   m_isRichText: 1
+  m_EmojiFallbackSupport: 1
   m_parseCtrlCharacters: 1
   m_isOrthographic: 1
   m_isCullingEnabled: 0
@@ -2331,9 +2154,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e1d4e8327e694ed4af86a3d735783a7a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  format: 0
   slider: {fileID: 980271482}
   valueText: {fileID: 910100004}
-  format: 0
 --- !u!114 &910100010
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2346,9 +2169,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e1d4e8327e694ed4af86a3d735783a7a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  format: 0
   slider: {fileID: 572837335}
   valueText: {fileID: 910100008}
-  format: 0
 --- !u!114 &910300001
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2363,21 +2186,21 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   backgroundTarget: {fileID: 2021325218}
   tabs:
-  - toggle: {fileID: 83767727}
+  - backgroundBottomExtension: 0
     content:
     - {fileID: 910400000}
     - {fileID: 914700000}
-    backgroundBottomExtension: 0
-  - toggle: {fileID: 379465458}
+    toggle: {fileID: 83767727}
+  - backgroundBottomExtension: 90
     content:
     - {fileID: 910300010}
     - {fileID: 914700100}
-    backgroundBottomExtension: 90
-  - toggle: {fileID: 2067048314}
+    toggle: {fileID: 379465458}
+  - backgroundBottomExtension: 380
     content:
     - {fileID: 913000000}
     - {fileID: 914700200}
-    backgroundBottomExtension: 380
+    toggle: {fileID: 2067048314}
 --- !u!1 &910300010
 GameObject:
   m_ObjectHideFlags: 0
@@ -4187,9 +4010,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a51e9d0fb6bd4b5c9c391c0adf4137ab, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  font: {fileID: 12800000, guid: e6fe47876853e974eaa14e1eb6a84372, type: 3}
   checkboxOutlineSprite: {fileID: 21300000, guid: e57e391bdb70226428c29572769ca462, type: 3}
   dataLoader: {fileID: 914500000}
+  font: {fileID: 12800000, guid: e6fe47876853e974eaa14e1eb6a84372, type: 3}
   logFilterDiagnostics: 0
 --- !u!1 &914000000
 GameObject:
@@ -4401,13 +4224,13 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9a93b0f869124c1fbbf024cf603ddc34, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  sourceInput: {fileID: 914600025}
-  loadButton: {fileID: 914600054}
-  statusText: {fileID: 914600073}
-  loadTimeoutSeconds: 30
-  loadPollSeconds: 0.25
   defaultSource: https://tiles.arcgis.com/tiles/V6ZHFr6zdgNZuVG0/arcgis/rest/services/BARNEGAT_BAY_LiDAR_UTM/SceneServer
+  loadButton: {fileID: 914600054}
   loadDefaultOnStart: 1
+  loadPollSeconds: 0.25
+  loadTimeoutSeconds: 30
+  sourceInput: {fileID: 914600025}
+  statusText: {fileID: 914600073}
 --- !u!1 &914546757
 GameObject:
   m_ObjectHideFlags: 0
@@ -5920,23 +5743,24 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 1fd84f1f8d4e4fe78f2f4dfb43a6123b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  dataLoader: {fileID: 914500000}
-  customizeController: {fileID: 914800000}
-  colorModulationToggle: {fileID: 914000008}
-  colorModulationLabel: {fileID: 910300030}
-  colorModulationDivider: {fileID: 910300040}
-  rgbToggle: {fileID: 910300102}
   classToggle: {fileID: 910300202}
+  colorModulationDivider: {fileID: 910300040}
+  colorModulationLabel: {fileID: 910300030}
+  colorModulationToggle: {fileID: 914000008}
+  customizeController: {fileID: 914800000}
+  dataLoader: {fileID: 914500000}
   elevationToggle: {fileID: 910300302}
-  intensityToggle: {fileID: 910300402}
-  visualizeTab: {fileID: 379465458}
-  rendererLegendRoot: {fileID: 912000001}
-  rendererLegendFont: {fileID: 12800000, guid: e6fe47876853e974eaa14e1eb6a84372, type: 3}
-  rendererLegendPanelOffset: {x: -40, y: 80}
-  instructionOpenButton: {fileID: 0}
-  instructionCloseButton: {fileID: 0}
+  filterTab: {fileID: 0}
   foldButton: {fileID: 1749334451}
   gearButton: {fileID: 1749334504}
+  instructionCloseButton: {fileID: 0}
+  instructionOpenButton: {fileID: 0}
+  intensityToggle: {fileID: 910300402}
+  rendererLegendFont: {fileID: 12800000, guid: e6fe47876853e974eaa14e1eb6a84372, type: 3}
+  rendererLegendPanelOffset: {x: -40, y: 80}
+  rendererLegendRoot: {fileID: 912000001}
+  rgbToggle: {fileID: 910300102}
+  visualizeTab: {fileID: 379465458}
 --- !u!1 &959710661
 GameObject:
   m_ObjectHideFlags: 0
@@ -6214,91 +6038,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1101178281}
   m_CullTransparentMesh: 1
---- !u!1001 &1151386841
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 590168736819191471, guid: e138313238356184eb0ec61dc02e90bb, type: 3}
-      propertyPath: InputTriggered.m_PersistentCalls.m_Calls.Array.size
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 590168736819191471, guid: e138313238356184eb0ec61dc02e90bb, type: 3}
-      propertyPath: InputTriggered.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 590168736819191471, guid: e138313238356184eb0ec61dc02e90bb, type: 3}
-      propertyPath: InputTriggered.m_PersistentCalls.m_Calls.Array.data[0].m_Target
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 590168736819191471, guid: e138313238356184eb0ec61dc02e90bb, type: 3}
-      propertyPath: InputTriggered.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 590168736819191471, guid: e138313238356184eb0ec61dc02e90bb, type: 3}
-      propertyPath: InputTriggered.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
-      value: StartMeasure
-      objectReference: {fileID: 0}
-    - target: {fileID: 590168736819191471, guid: e138313238356184eb0ec61dc02e90bb, type: 3}
-      propertyPath: InputTriggered.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
-      value: Measure, Sample Viewer
-      objectReference: {fileID: 0}
-    - target: {fileID: 590168736819191471, guid: e138313238356184eb0ec61dc02e90bb, type: 3}
-      propertyPath: InputTriggered.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
-      value: UnityEngine.Object, UnityEngine
-      objectReference: {fileID: 0}
-    - target: {fileID: 8139233274423697264, guid: e138313238356184eb0ec61dc02e90bb, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8139233274423697264, guid: e138313238356184eb0ec61dc02e90bb, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8139233274423697264, guid: e138313238356184eb0ec61dc02e90bb, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8139233274423697264, guid: e138313238356184eb0ec61dc02e90bb, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8139233274423697264, guid: e138313238356184eb0ec61dc02e90bb, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8139233274423697264, guid: e138313238356184eb0ec61dc02e90bb, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8139233274423697264, guid: e138313238356184eb0ec61dc02e90bb, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8139233274423697264, guid: e138313238356184eb0ec61dc02e90bb, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8139233274423697264, guid: e138313238356184eb0ec61dc02e90bb, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8139233274423697264, guid: e138313238356184eb0ec61dc02e90bb, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8654319820097538438, guid: e138313238356184eb0ec61dc02e90bb, type: 3}
-      propertyPath: m_Name
-      value: InputManager
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: e138313238356184eb0ec61dc02e90bb, type: 3}
 --- !u!1 &1163267375
 GameObject:
   m_ObjectHideFlags: 0
@@ -6844,20 +6583,23 @@ MonoBehaviour:
   m_VerticalAlignment: 256
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
   m_paragraphSpacing: 0
   m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 0
+  m_TextWrappingMode: 0
   m_wordWrappingRatios: 0.4
   m_overflowMode: 0
   m_linkedTextComponent: {fileID: 0}
   parentLinkedComponent: {fileID: 0}
   m_enableKerning: 1
+  m_ActiveFontFeatures: 6e72656b
   m_enableExtraPadding: 0
   checkPaddingRequired: 0
   m_isRichText: 1
+  m_EmojiFallbackSupport: 1
   m_parseCtrlCharacters: 1
   m_isOrthographic: 1
   m_isCullingEnabled: 0
@@ -7385,7 +7127,6 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 150318281}
-  - {fileID: 820472295}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1808036065
@@ -7400,6 +7141,13 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c703502c1493f5b4eb3e95b2efe0271e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  dataFetchWithSceneView: 1
+  editorModeEnabled: 1
+  rebaseWithSceneView: 0
+  RootChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  isInitialized: 1
   apiKey: 
   basemap: https://www.arcgis.com/home/item.html?id=90f86b329f37499096d3715ac6e5ed1f
   basemapType: 0
@@ -7437,9 +7185,9 @@ MonoBehaviour:
     UseOriginAsCenter: 0
   layers: []
   originPosition:
-    X: -122.4783
-    Y: 37.8199
-    Z: 1300
+    X: -74.11597546017596
+    Y: 39.780053361415895
+    Z: 0
     SRWkid: 4326
     SpatialReference:
       WKID: 4326
@@ -7450,17 +7198,10 @@ MonoBehaviour:
   customMapSpatialReference:
     WKID: 3857
     VerticalWKID: 0
-  meshCollidersEnabled: 1
+  meshCollidersEnabled: 0
   configurations: []
   oauthUserConfigurations: []
   version: 4
-  dataFetchWithSceneView: 1
-  editorModeEnabled: 1
-  rebaseWithSceneView: 0
-  RootChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  isInitialized: 1
 --- !u!114 &1808036066
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -7474,9 +7215,9 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_LocalPosition:
-    x: -13634221.989225801
-    y: 1300
-    z: 4554014.871240516
+    x: -8250552.647873549
+    y: 0
+    z: 4834031.521886496
   m_LocalRotation:
     value:
       x: 0
@@ -7836,12 +7577,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d5ee884efaf64db4bb2df363dd85cd0b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  toggle: {fileID: 2067048314}
+  normalSprite: {fileID: 21300000, guid: 443784a928b73e04fa92e1a5780174c2, type: 3}
+  selectedSprite: {fileID: 21300000, guid: cfb6157a0d1b4fbd8f93f0b6901be5e2, type: 3}
   targetImages:
   - {fileID: 2067048315}
   - {fileID: 1781786004}
-  selectedSprite: {fileID: 21300000, guid: cfb6157a0d1b4fbd8f93f0b6901be5e2, type: 3}
-  normalSprite: {fileID: 21300000, guid: 443784a928b73e04fa92e1a5780174c2, type: 3}
+  toggle: {fileID: 2067048314}
 --- !u!1 &2110832572
 GameObject:
   m_ObjectHideFlags: 0
@@ -7937,20 +7678,23 @@ MonoBehaviour:
   m_VerticalAlignment: 256
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
   m_paragraphSpacing: 0
   m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 0
+  m_TextWrappingMode: 0
   m_wordWrappingRatios: 0.4
   m_overflowMode: 0
   m_linkedTextComponent: {fileID: 0}
   parentLinkedComponent: {fileID: 0}
   m_enableKerning: 1
+  m_ActiveFontFeatures: 6e72656b
   m_enableExtraPadding: 0
   checkPaddingRequired: 0
   m_isRichText: 1
+  m_EmojiFallbackSupport: 1
   m_parseCtrlCharacters: 1
   m_isOrthographic: 1
   m_isCullingEnabled: 0
@@ -8249,7 +7993,7 @@ GameObject:
   m_IsActive: 1
 --- !u!95 &8225324983540084672
 Animator:
-  serializedVersion: 5
+  serializedVersion: 7
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
@@ -8263,6 +8007,7 @@ Animator:
   m_ApplyRootMotion: 0
   m_LinearVelocityBlending: 0
   m_StabilizeFeet: 0
+  m_AnimatePhysics: 0
   m_WarningMessage: 
   m_HasTransformHierarchy: 1
   m_AllowConstantClipSamplingOptimization: 1
@@ -8594,7 +8339,7 @@ CanvasRenderer:
   m_CullTransparentMesh: 1
 --- !u!95 &8397983937561900139
 Animator:
-  serializedVersion: 5
+  serializedVersion: 7
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
@@ -8608,6 +8353,7 @@ Animator:
   m_ApplyRootMotion: 0
   m_LinearVelocityBlending: 0
   m_StabilizeFeet: 0
+  m_AnimatePhysics: 0
   m_WarningMessage: 
   m_HasTransformHierarchy: 1
   m_AllowConstantClipSamplingOptimization: 1
@@ -8718,20 +8464,23 @@ MonoBehaviour:
   m_VerticalAlignment: 256
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
   m_paragraphSpacing: 0
   m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 0
+  m_TextWrappingMode: 0
   m_wordWrappingRatios: 0.4
   m_overflowMode: 0
   m_linkedTextComponent: {fileID: 0}
   parentLinkedComponent: {fileID: 0}
   m_enableKerning: 1
+  m_ActiveFontFeatures: 6e72656b
   m_enableExtraPadding: 0
   checkPaddingRequired: 0
   m_isRichText: 1
+  m_EmojiFallbackSupport: 1
   m_parseCtrlCharacters: 1
   m_isOrthographic: 1
   m_isCullingEnabled: 0
@@ -8873,20 +8622,23 @@ MonoBehaviour:
   m_VerticalAlignment: 256
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
   m_paragraphSpacing: 0
   m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 0
+  m_TextWrappingMode: 0
   m_wordWrappingRatios: 0.4
   m_overflowMode: 0
   m_linkedTextComponent: {fileID: 0}
   parentLinkedComponent: {fileID: 0}
   m_enableKerning: 1
+  m_ActiveFontFeatures: 6e72656b
   m_enableExtraPadding: 0
   checkPaddingRequired: 0
   m_isRichText: 1
+  m_EmojiFallbackSupport: 1
   m_parseCtrlCharacters: 1
   m_isOrthographic: 1
   m_isCullingEnabled: 0
@@ -9158,4 +8910,3 @@ SceneRoots:
   - {fileID: 8225324984385568675}
   - {fileID: 74418451}
   - {fileID: 1307272098}
-  - {fileID: 1151386841}

--- a/sample_project/Assets/SampleViewer/Samples/PointCloudLayer/PointCloudLayerDataLoader.cs
+++ b/sample_project/Assets/SampleViewer/Samples/PointCloudLayer/PointCloudLayerDataLoader.cs
@@ -196,6 +196,7 @@ public sealed class PointCloudLayerDataLoader : MonoBehaviour
 			loadedSource = source;
 			RemovePointCloudLayersExcept(newLayerIndex);
 			LayerLoaded?.Invoke(newLayer);
+            arcGISMapComponent.OriginPosition = newLayer.Extent.Center;
 			yield return ZoomToLoadedLayer(newLayer);
 			ShowStatus("Layer loaded successfully...", successColor);
 		}


### PR DESCRIPTION

**Sample**
Point cloud layer: when a new layer is loaded, map origin is now moved to layer extent to avoid visual artifacts or flickering.
Other changes in scene: change map origin, remove unused GOs, disable mesh
 
**Checklist**

<!--- Delete any that don't apply -->

- [x] PR title follows convention - `keyword: Short description of change` <!--- Example:  ansible: Update build scripts to handle new engine versions -->
- [x] PR targets the correct branch <!-- Changes going into `main` work with the current public release of the plugin-->
- [x] Self-review of changes
- [x] There are no warnings related to changes
- [ ] A build was made and tested on all relevant platforms
- [x] No unrelated changes have been made to any other code or project files
- [x] No unnecessary includes or namespaces added
- [x] New code and changed code has proper formatting <!-- Run a formatter if unsure -->
- [x] No unintentional formatting changes
- [x] Commits have descriptive titles

**ArcGIS Maps SDK Version**
2.4